### PR TITLE
Remove target_compatible_with restriction

### DIFF
--- a/csharp/private/toolchains.bzl
+++ b/csharp/private/toolchains.bzl
@@ -39,10 +39,6 @@ def configure_toolchain(os, exe = "dotnet"):
             "@platforms//cpu:x86_64",
         ],
 
-        # TODO: this will need to change when we build someting other then .NET 4.x
-        target_compatible_with = [
-            "@platforms//os:windows",
-        ],
         toolchain = "csharp_x86_64-" + os,
         toolchain_type = ":toolchain_type",
     )


### PR DESCRIPTION
This restriction isn't particularly valid in the long run. You could consider trying to do it when building .NET Framework targets, but given you can use mono as a runtime, that still isn't particularly correct