### PR TITLE
Stop after the first compatible framework

### DIFF
--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -68,6 +68,7 @@ def fill_in_missing_frameworks(providers):
                 deps = base.deps,
                 transitive_refs = refs,
             )
+            break
 
 def get_analyzer_dll(analyzer_target):
     return analyzer_target[CSharpAssembly["netstandard"]]


### PR DESCRIPTION
This was a minor bug I noticed when building `//examples:lib_test`.