### PR TITLE
Don't allow netstandard framworks for executables

### DIFF
--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -16,6 +16,9 @@ def is_debug(ctx):
     # equivalent to dbg right now but might want to support this in the future.
     return ctx.var["COMPILATION_MODE"] != "opt"
 
+def is_standard_framework(tfm):
+    return tfm.startswith("netstandard")
+
 def collect_transitive_info(deps, tfm):
     direct = []
     transitive = []

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -6,12 +6,16 @@ load(
     "DEFAULT_TARGET_FRAMEWORK",
     "fill_in_missing_frameworks",
     "is_debug",
+    "is_standard_framework",
 )
 
 def _binary_impl(ctx):
     providers = {}
 
     for tfm in ctx.attr.target_frameworks:
+        if is_standard_framework(tfm):
+            fail("It doesn't make sense to build an executable for " + tfm)
+
         providers[tfm] = AssemblyAction(
             ctx.actions,
             name = ctx.attr.name,

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -6,6 +6,7 @@ load(
     "DEFAULT_TARGET_FRAMEWORK",
     "fill_in_missing_frameworks",
     "is_debug",
+    "is_standard_framework",
 )
 
 def _nunit_test_impl(ctx):
@@ -14,6 +15,9 @@ def _nunit_test_impl(ctx):
     extra_deps = [ctx.attr._nunitlite, ctx.attr._nunitframework]
 
     for tfm in ctx.attr.target_frameworks:
+        if is_standard_framework(tfm):
+            fail("It doesn't make sense to build an executable for " + tfm)
+
         providers[tfm] = AssemblyAction(
             ctx.actions,
             name = ctx.attr.name,


### PR DESCRIPTION
This just makes sure we have a good error message if the user tries it.
Fixing this brought to light that we don't actually support .NET
Standard tests because we are producing an exe for Bazel to run. We
should still do that, but without modifying the users assembly (our shim
can link the tests in at runtime).

Fixes #5.