### PR TITLE
Add runfiles to binary outputs

### DIFF
--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -90,7 +90,7 @@ def AssemblyAction(
     args.add("/pdb:" + pdb.path)
 
     # assembly references
-    refs = collect_transitive_info(deps, target_framework)
+    (refs, runfiles) = collect_transitive_info(deps, target_framework)
     args.add_all(refs, map_each = _format_ref_arg)
 
     # analyzers
@@ -160,4 +160,5 @@ def AssemblyAction(
         pdb = pdb,
         deps = deps,
         transitive_refs = refs,
+        transitive_runfiles = runfiles,
     )

--- a/csharp/private/providers.bzl
+++ b/csharp/private/providers.bzl
@@ -15,6 +15,7 @@ def _make_csharp_provider(tfm):
             "pdb": "debug symbols",
             "deps": "the non-transitive dependencies for this assembly (used by import_multiframework_library).",
             "transitive_refs": "A list of other assemblies to reference when referencing this assembly in a compilation.",
+            "transitive_runfiles": "Runfiles from the transitive dependencies.",
         },
     )
 

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -37,6 +37,10 @@ def _binary_impl(ctx):
     result = providers.values()
     result.append(DefaultInfo(
         executable = result[0].out,
+        runfiles = ctx.runfiles(
+            files = [result[0].out, result[0].pdb],
+            transitive_files = result[0].transitive_runfiles,
+        ),
         files = depset([result[0].out, result[0].refout, result[0].pdb]),
     ))
 

--- a/csharp/private/rules/imports.bzl
+++ b/csharp/private/rules/imports.bzl
@@ -22,16 +22,16 @@ def _import_library(ctx):
 
     tfm = ctx.attr.target_framework
 
+    (refs, runfiles) = collect_transitive_info(ctx.attr.deps, tfm)
+
     providers = {
         tfm: CSharpAssembly[tfm](
             out = ctx.file.dll,
             refout = ctx.file.refdll,
             pdb = ctx.file.pdb,
             deps = ctx.attr.deps,
-            transitive_refs = collect_transitive_info(
-                ctx.attr.deps,
-                tfm,
-            ),
+            transitive_refs = refs,
+            transitive_runfiles = runfiles,
         ),
     }
 

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -39,6 +39,10 @@ def _nunit_test_impl(ctx):
     result = providers.values()
     result.append(DefaultInfo(
         executable = result[0].out,
+        runfiles = ctx.runfiles(
+            files = [result[0].out, result[0].pdb],
+            transitive_files = result[0].transitive_runfiles,
+        ),
         files = depset([result[0].out, result[0].refout, result[0].pdb]),
     ))
 


### PR DESCRIPTION
This goes towards #9, but doesn't fix it. We still need to deal with how
these files aren't all collected into a single directory.