### PR TITLE
Fix glob

### DIFF
--- a/csharp/private/runtime.BUILD
+++ b/csharp/private/runtime.BUILD
@@ -2,6 +2,8 @@ exports_files(
     glob([
         "dotnet",
         "dotnet.exe",  # windows, yeesh
+    ], allow_empty = True) +
+    glob([
         "host/**/*",
         "shared/**/*",
     ]),


### PR DESCRIPTION
It will soon be an error for a glob to return an empty set. This is
gated behind --incompatible_disallow_empty_glob currently.