### PR TITLE
Add .bazelci/presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,30 @@
+---
+bazel: 0.29.1
+tasks:
+  examples-windows:
+    name: Examples on Windows
+    platform: windows
+    include_json_profile:
+    - build
+    - test
+    working_directory: examples
+    build_targets:
+    - ...
+  examples-ubuntu1804:
+    name: Examples on Ubuntu 18.04
+    platform: ubuntu1804
+    include_json_profile:
+    - build
+    - test
+    working_directory: examples
+    build_targets:
+    - ...
+  examples-macos:
+    name: Examples on macOS
+    platform: macos
+    include_json_profile:
+    - build
+    - test
+    working_directory: examples
+    build_targets:
+    - ...


### PR DESCRIPTION
Related to #42 

I also need to submit an issue in their repo, according to [the documentation](https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md).

I've kept this pretty basic. We'd like to test on the 3 major platforms. There are some other things I'd like in the future:

- run & test targets: blocked on #9 
- buildifier linting: blocked on us formatting our code
- using remote builds (i.e. the `rbe_ubuntu1604` platform): this is probably blocked on as-of-yet-unfiled issue where we have a bit too many implicit dependencies on the exec environment (e.g. libicu) it's why we aren't doing `bazel build` inside our GitHub action (which runs in the "official" Bazel containers, which RBE may use...)

For the extra stuff that might not succeed on attempt 1 it'll be easier to add those as follow-ups, once we can trigger CI :) My goal is to just get something basic working.