### PR TITLE
Add a .bazelrc in examples for CI

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,0 +1,2 @@
+build --sandbox_tmpfs_path=/tmp
+test --sandbox_tmpfs_path=/tmp


### PR DESCRIPTION
--sandbox_tmpfs_path=/tmp removes the flake we see in Linux due to what
is probably a bug in the dotnet runtime.

This is being tracked in issue #45.

It struck me that this is probably a good thing to do before bazel-ci.