### PR TITLE
Allow CSharpProviders to have neither out/refout

### DIFF
--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -30,8 +30,12 @@ def collect_transitive_info(deps, tfm):
 
         assembly = dep[provider]
 
-        # See docs/ReferenceAssemblies.md for more info on why we use refout
-        direct_refs.append(assembly.refout or assembly.out)
+        # See docs/ReferenceAssemblies.md for more info on why we use (and prefer) refout
+        if assembly.refout:
+            direct_refs.append(assembly.refout)
+        elif assembly.out:
+            direct_refs.append(assembly.out)
+
         transitive_refs.append(assembly.transitive_refs)
 
         if assembly.out:

--- a/csharp/private/providers.bzl
+++ b/csharp/private/providers.bzl
@@ -8,7 +8,7 @@ See docs/MultiTargetingDesign.md for more info.
 
 def _make_csharp_provider(tfm):
     return provider(
-        doc = "A (usually C#) DLL or exe, targetting %s. One of out or refout must exist." % tfm,
+        doc = "A (usually C#) DLL or exe, targetting %s." % tfm,
         fields = {
             "out": "a dll (for libraries and tests) or an exe (for binaries).",
             "refout": "A reference-only DLL/exe. See docs/ReferenceAssemblies.md for more info.",


### PR DESCRIPTION
This is the easy part for #41.

The next step is to add csharp_library_set, which only has the deps
attribute. That's seems to be slightly non-trivial because our existing
helpers don't quite cut it.

The final piece of the puzzle is creating the @net//:StandardLibrary
target with a csharp_library_set that deps on @net48//:StandardLibrary
etc. That's easy but a bit tedious.