### PR TITLE
Add a stdlib attribute to the compilation rules

### DIFF
--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -10,7 +10,7 @@ load(
 def _binary_impl(ctx):
     providers = {}
 
-    stdlib = [ctx.attr.stdlib] if ctx.attr.stdlib else []
+    stdlib = [ctx.attr._stdlib] if ctx.attr.stdlib else []
 
     for tfm in ctx.attr.target_frameworks:
         if is_standard_framework(tfm):
@@ -84,7 +84,11 @@ csharp_binary = rule(
                   "output a console-style executable.",
             default = False,
         ),
-        "stdlib": attr.label(
+        "stdlib": attr.bool(
+            doc = "Whether to reference @net//:StandardLibrary (the default set of references that MSBuild adds to every project).",
+            default = True,
+        ),
+        "_stdlib": attr.label(
             doc = "The standard library to reference. Set to None if you don't want one.",
             default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
         ),

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -10,7 +10,7 @@ load(
 def _binary_impl(ctx):
     providers = {}
 
-    stdlib = [ctx.attr._stdlib] if ctx.attr.stdlib else []
+    stdrefs = [ctx.attr._stdrefs] if ctx.attr.include_stdrefs else []
 
     for tfm in ctx.attr.target_frameworks:
         if is_standard_framework(tfm):
@@ -23,7 +23,7 @@ def _binary_impl(ctx):
             analyzers = ctx.attr.analyzers,
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
-            deps = ctx.attr.deps + stdlib,
+            deps = ctx.attr.deps + stdrefs,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs,
@@ -84,13 +84,13 @@ csharp_binary = rule(
                   "output a console-style executable.",
             default = False,
         ),
-        "stdlib": attr.bool(
-            doc = "Whether to reference @net//:StandardLibrary (the default set of references that MSBuild adds to every project).",
+        "include_stdrefs": attr.bool(
+            doc = "Whether to reference @net//:StandardReferences (the default set of references that MSBuild adds to every project).",
             default = True,
         ),
-        "_stdlib": attr.label(
-            doc = "The standard library to reference. Set to None if you don't want one.",
-            default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
+        "_stdrefs": attr.label(
+            doc = "The standard set of assemblies to reference.",
+            default = "@net//:mscorlib", # TODO: change to @net//:StandardReferences once it exists
         ),
         "deps": attr.label_list(
             doc = "Other C# libraries, binaries, or imported DLLs",

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -10,6 +10,8 @@ load(
 def _binary_impl(ctx):
     providers = {}
 
+    stdlib = [ctx.attr.stdlib] if ctx.attr.stdlib else []
+
     for tfm in ctx.attr.target_frameworks:
         if is_standard_framework(tfm):
             fail("It doesn't make sense to build an executable for " + tfm)
@@ -21,7 +23,7 @@ def _binary_impl(ctx):
             analyzers = ctx.attr.analyzers,
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
-            deps = ctx.attr.deps,
+            deps = ctx.attr.deps + stdlib,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs,
@@ -81,6 +83,10 @@ csharp_binary = rule(
             doc = "If true, output a winexe-style executable, otherwise" +
                   "output a console-style executable.",
             default = False,
+        ),
+        "stdlib": attr.label(
+            doc = "The standard library to reference. Set to None if you don't want one.",
+            default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
         ),
         "deps": attr.label_list(
             doc = "Other C# libraries, binaries, or imported DLLs",

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -9,7 +9,7 @@ load(
 def _library_impl(ctx):
     providers = {}
 
-    stdlib = [ctx.attr.stdlib] if ctx.attr.stdlib else []
+    stdlib = [ctx.attr._stdlib] if ctx.attr.stdlib else []
 
     for tfm in ctx.attr.target_frameworks:
         providers[tfm] = AssemblyAction(
@@ -70,8 +70,12 @@ csharp_library = rule(
             default = [],
             allow_empty = True,
         ),
-        "stdlib": attr.label(
-            doc = "The standard library to reference. Set to None if you don't want one.",
+        "stdlib": attr.bool(
+            doc = "Whether to reference @net//:StandardLibrary (the default set of references that MSBuild adds to every project).",
+            default = True,
+        ),
+        "_stdlib": attr.label(
+            doc = "The standard library to reference.",
             default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
         ),
         "deps": attr.label_list(

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -9,6 +9,8 @@ load(
 def _library_impl(ctx):
     providers = {}
 
+    stdlib = [ctx.attr.stdlib] if ctx.attr.stdlib else []
+
     for tfm in ctx.attr.target_frameworks:
         providers[tfm] = AssemblyAction(
             ctx.actions,
@@ -17,7 +19,7 @@ def _library_impl(ctx):
             analyzers = ctx.attr.analyzers,
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
-            deps = ctx.attr.deps,
+            deps = ctx.attr.deps + stdlib,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs,
@@ -67,6 +69,10 @@ csharp_library = rule(
             doc = "A list of preprocessor directive symbols to define.",
             default = [],
             allow_empty = True,
+        ),
+        "stdlib": attr.label(
+            doc = "The standard library to reference. Set to None if you don't want one.",
+            default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
         ),
         "deps": attr.label_list(
             doc = "Other C# libraries, binaries, or imported DLLs",

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -9,7 +9,7 @@ load(
 def _library_impl(ctx):
     providers = {}
 
-    stdlib = [ctx.attr._stdlib] if ctx.attr.stdlib else []
+    stdrefs = [ctx.attr._stdrefs] if ctx.attr.include_stdrefs else []
 
     for tfm in ctx.attr.target_frameworks:
         providers[tfm] = AssemblyAction(
@@ -19,7 +19,7 @@ def _library_impl(ctx):
             analyzers = ctx.attr.analyzers,
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
-            deps = ctx.attr.deps + stdlib,
+            deps = ctx.attr.deps + stdrefs,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs,
@@ -70,13 +70,13 @@ csharp_library = rule(
             default = [],
             allow_empty = True,
         ),
-        "stdlib": attr.bool(
-            doc = "Whether to reference @net//:StandardLibrary (the default set of references that MSBuild adds to every project).",
+        "include_stdrefs": attr.bool(
+            doc = "Whether to reference @net//:StandardReferences (the default set of references that MSBuild adds to every project).",
             default = True,
         ),
-        "_stdlib": attr.label(
-            doc = "The standard library to reference.",
-            default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
+        "_stdrefs": attr.label(
+            doc = "The standard set of assemblies to reference.",
+            default = "@net//:mscorlib", # TODO: change to @net//:StandardReferences once it exists
         ),
         "deps": attr.label_list(
             doc = "Other C# libraries, binaries, or imported DLLs",

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -11,7 +11,7 @@ def _nunit_test_impl(ctx):
     providers = {}
 
     extra_deps = [ctx.attr._nunitlite, ctx.attr._nunitframework]
-    stdlib = [ctx.attr.stdlib] if ctx.attr.stdlib else []
+    stdlib = [ctx.attr._stdlib] if ctx.attr.stdlib else []
 
     for tfm in ctx.attr.target_frameworks:
         if is_standard_framework(tfm):
@@ -80,7 +80,11 @@ csharp_nunit_test = rule(
             default = [],
             allow_empty = True,
         ),
-        "stdlib": attr.label(
+        "stdlib": attr.bool(
+            doc = "Whether to reference @net//:StandardLibrary (the default set of references that MSBuild adds to every project).",
+            default = True,
+        ),
+        "_stdlib": attr.label(
             doc = "The standard library to reference. Set to None if you don't want one.",
             default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
         ),

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -11,6 +11,7 @@ def _nunit_test_impl(ctx):
     providers = {}
 
     extra_deps = [ctx.attr._nunitlite, ctx.attr._nunitframework]
+    stdlib = [ctx.attr.stdlib] if ctx.attr.stdlib else []
 
     for tfm in ctx.attr.target_frameworks:
         if is_standard_framework(tfm):
@@ -23,7 +24,7 @@ def _nunit_test_impl(ctx):
             analyzers = ctx.attr.analyzers,
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
-            deps = ctx.attr.deps + extra_deps,
+            deps = ctx.attr.deps + extra_deps + stdlib,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs + [ctx.file._nunit_shim],
@@ -78,6 +79,10 @@ csharp_nunit_test = rule(
             doc = "A list of preprocessor directive symbols to define.",
             default = [],
             allow_empty = True,
+        ),
+        "stdlib": attr.label(
+            doc = "The standard library to reference. Set to None if you don't want one.",
+            default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
         ),
         "deps": attr.label_list(
             doc = "Other C# libraries, binaries, or imported DLLs",

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -11,7 +11,7 @@ def _nunit_test_impl(ctx):
     providers = {}
 
     extra_deps = [ctx.attr._nunitlite, ctx.attr._nunitframework]
-    stdlib = [ctx.attr._stdlib] if ctx.attr.stdlib else []
+    stdrefs = [ctx.attr._stdrefs] if ctx.attr.include_stdrefs else []
 
     for tfm in ctx.attr.target_frameworks:
         if is_standard_framework(tfm):
@@ -24,7 +24,7 @@ def _nunit_test_impl(ctx):
             analyzers = ctx.attr.analyzers,
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
-            deps = ctx.attr.deps + extra_deps + stdlib,
+            deps = ctx.attr.deps + extra_deps + stdrefs,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs + [ctx.file._nunit_shim],
@@ -80,13 +80,13 @@ csharp_nunit_test = rule(
             default = [],
             allow_empty = True,
         ),
-        "stdlib": attr.bool(
-            doc = "Whether to reference @net//:StandardLibrary (the default set of references that MSBuild adds to every project).",
+        "include_stdrefs": attr.bool(
+            doc = "Whether to reference @net//:StandardReferences (the default set of references that MSBuild adds to every project).",
             default = True,
         ),
-        "_stdlib": attr.label(
-            doc = "The standard library to reference. Set to None if you don't want one.",
-            default = "@net//:mscorlib", # TODO: change to @net//:StandardLibrary once it exists
+        "_stdrefs": attr.label(
+            doc = "The standard set of assemblies to reference.",
+            default = "@net//:mscorlib", # TODO: change to @net//:StandardReferences once it exists
         ),
         "deps": attr.label_list(
             doc = "Other C# libraries, binaries, or imported DLLs",

--- a/examples/diamond/BUILD
+++ b/examples/diamond/BUILD
@@ -29,10 +29,10 @@ csharp_library(
 csharp_library(
     name = "Bottom",
     srcs = ["Bottom.cs"],
+    stdlib = False, # TODO: remove this when we support netstandard1.4's stdlib
     target_frameworks= [
         "net48",
         "net40",
-        # TODO: change this back to "netstandard1.4" when we support it
-        "netstandard2.0",
+        "netstandard1.4",
     ],
 )

--- a/examples/diamond/BUILD
+++ b/examples/diamond/BUILD
@@ -29,7 +29,7 @@ csharp_library(
 csharp_library(
     name = "Bottom",
     srcs = ["Bottom.cs"],
-    stdlib = False, # TODO: remove this when we support netstandard1.4's stdlib
+    include_stdrefs = False, # TODO: remove this when we support netstandard1.4's stdlib
     target_frameworks= [
         "net48",
         "net40",

--- a/examples/diamond/BUILD
+++ b/examples/diamond/BUILD
@@ -29,5 +29,10 @@ csharp_library(
 csharp_library(
     name = "Bottom",
     srcs = ["Bottom.cs"],
-    target_frameworks= ["net48", "net40", "netstandard1.4"],
+    target_frameworks= [
+        "net48",
+        "net40",
+        # TODO: change this back to "netstandard1.4" when we support it
+        "netstandard2.0",
+    ],
 )


### PR DESCRIPTION
This is another incremental step towards #41.

The default value will be @net//:StandardLibrary eventually, and the
idea is that if you don't want this you can set the attr to be None
explicitly.