### PR TITLE
Add 'out' attribute to assembly-building commands

### DIFF
--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -58,7 +58,7 @@ def AssemblyAction(
         target_framework,
         toolchain):
 
-    out_file_name = name if out == None else out
+    out_file_name = name if out == "" else out
     out_dir = "bazelout/" + target_framework
     out_ext = "dll" if target == "library" else "exe"
     out_file = actions.declare_file("%s/%s.%s" % (out_dir, out_file_name, out_ext))

--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -53,15 +53,17 @@ def AssemblyAction(
         langversion,
         resources,
         srcs,
+        out,
         target,
         target_framework,
         toolchain):
 
+    out_file_name = name if out == None else out
     out_dir = "bazelout/" + target_framework
     out_ext = "dll" if target == "library" else "exe"
-    out = actions.declare_file("%s/%s.%s" % (out_dir, name, out_ext))
-    refout = actions.declare_file("%s/%s.ref.%s" % (out_dir, name, out_ext))
-    pdb = actions.declare_file("%s/%s.pdb" % (out_dir, name))
+    out_file = actions.declare_file("%s/%s.%s" % (out_dir, out_file_name, out_ext))
+    refout = actions.declare_file("%s/%s.ref.%s" % (out_dir, out_file_name, out_ext))
+    pdb = actions.declare_file("%s/%s.pdb" % (out_dir, out_file_name))
 
     # Our goal is to match msbuild as much as reasonable
     # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/listed-alphabetically
@@ -101,7 +103,7 @@ def AssemblyAction(
     args.add("/debug:portable")
 
     # outputs
-    args.add("/out:" + out.path)
+    args.add("/out:" + out_file.path)
     args.add("/refout:" + refout.path)
     args.add("/pdb:" + pdb.path)
 
@@ -158,7 +160,7 @@ def AssemblyAction(
                      [toolchain.compiler],
             transitive = [refs],
         ),
-        outputs = [out, refout, pdb],
+        outputs = [out_file, refout, pdb],
         executable = toolchain.runtime,
         arguments = [
             toolchain.compiler.path,
@@ -171,7 +173,7 @@ def AssemblyAction(
     )
 
     return CSharpAssembly[target_framework](
-        out = out,
+        out = out_file,
         refout = refout,
         pdb = pdb,
         deps = deps,

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -27,6 +27,7 @@ def _binary_impl(ctx):
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs,
+            out = ctx.attr.out,
             target = "winexe" if ctx.attr.winexe else "exe",
             target_framework = tfm,
             toolchain = ctx.toolchains["@d2l_rules_csharp//csharp/private:toolchain_type"],
@@ -68,6 +69,9 @@ csharp_binary = rule(
         "resources": attr.label_list(
             doc = "A list of files to embed in the DLL as resources.",
             allow_files = True,
+        ),
+        "out": attr.string(
+            doc = "File name, without extension, of the built assembly.",
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -72,7 +72,7 @@ csharp_binary = rule(
         ),
         "out": attr.string(
             doc = "File name, without extension, of the built assembly.",
-            default = None,
+            default = "",
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -72,7 +72,6 @@ csharp_binary = rule(
         ),
         "out": attr.string(
             doc = "File name, without extension, of the built assembly.",
-            default = "",
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -72,6 +72,7 @@ csharp_binary = rule(
         ),
         "out": attr.string(
             doc = "File name, without extension, of the built assembly.",
+            default = None,
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -63,7 +63,6 @@ csharp_library = rule(
         ),
         "out": attr.string(
             doc = "File name, without extension, of the built assembly.",
-            default = "",
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -63,6 +63,7 @@ csharp_library = rule(
         ),
         "out": attr.string(
             doc = "File name, without extension, of the built assembly.",
+            default = None,
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -63,7 +63,7 @@ csharp_library = rule(
         ),
         "out": attr.string(
             doc = "File name, without extension, of the built assembly.",
-            default = None,
+            default = "",
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -23,6 +23,7 @@ def _library_impl(ctx):
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs,
+            out = ctx.attr.out,
             target = "library",
             target_framework = tfm,
             toolchain = ctx.toolchains["@d2l_rules_csharp//csharp/private:toolchain_type"],
@@ -59,6 +60,9 @@ csharp_library = rule(
         "resources": attr.label_list(
             doc = "A list of files to embed in the DLL as resources.",
             allow_files = True,
+        ),
+        "out": attr.string(
+            doc = "File name, without extension, of the built assembly.",
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -73,7 +73,6 @@ csharp_nunit_test = rule(
         ),
         "out": attr.string(
             doc = "File name, without extension, of the built assembly.",
-            default = "",
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -73,7 +73,7 @@ csharp_nunit_test = rule(
         ),
         "out": attr.string(
             doc = "File name, without extension, of the built assembly.",
-            default = None,
+            default = "",
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -28,6 +28,7 @@ def _nunit_test_impl(ctx):
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs + [ctx.file._nunit_shim],
+            out = ctx.attr.out,
             target = "exe",
             target_framework = tfm,
             toolchain = ctx.toolchains["@d2l_rules_csharp//csharp/private:toolchain_type"],
@@ -69,6 +70,10 @@ csharp_nunit_test = rule(
         "resources": attr.label_list(
             doc = "A list of files to embed in the DLL as resources.",
             allow_files = True,
+        ),
+        "out": attr.string(
+            doc = "File name, without extension, of the built assembly.",
+            default = None,
         ),
         "target_frameworks": attr.string_list(
             doc = "A list of target framework monikers to build" +


### PR DESCRIPTION
This decouples the name of the built assembly from the name of the
Bazel target. If not specified, the name of the target is used.

Fixes #73.