### PR TITLE
Adding strong-naming via /keyfile: compiler switch

### DIFF
--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -50,6 +50,7 @@ def AssemblyAction(
         debug,
         defines,
         deps,
+        keyfile,
         langversion,
         resources,
         srcs,
@@ -128,6 +129,10 @@ def AssemblyAction(
         _framework_preprocessor_symbols(target_framework) + defines,
         map_each = _format_define,
     )
+
+    # keyfile
+    if keyfile != None:
+        args.add("/keyfile:" + keyfile.path)
 
     # TODO:
     # - appconfig(?)

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -24,6 +24,7 @@ def _binary_impl(ctx):
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
             deps = ctx.attr.deps + stdrefs,
+            keyfile = ctx.file.keyfile,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs,
@@ -62,6 +63,10 @@ csharp_binary = rule(
         "analyzers": attr.label_list(
             doc = "A list of analyzer references.",
             providers = AnyTargetFramework,
+        ),
+        "keyfile": attr.label(
+            doc = "The key file used to sign the assembly with a strong name.",
+            allow_single_file = True,
         ),
         "langversion": attr.string(
             doc = "The version string for the C# language.",

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -20,6 +20,7 @@ def _library_impl(ctx):
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
             deps = ctx.attr.deps + stdrefs,
+            keyfile = ctx.file.keyfile,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs,
@@ -53,6 +54,10 @@ csharp_library = rule(
         "analyzers": attr.label_list(
             doc = "A list of analyzer references.",
             providers = AnyTargetFramework,
+        ),
+        "keyfile": attr.label(
+            doc = "The key file used to sign the assembly with a strong name.",
+            allow_single_file = True,
         ),
         "langversion": attr.string(
             doc = "The version string for the C# language.",

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -25,6 +25,7 @@ def _nunit_test_impl(ctx):
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
             deps = ctx.attr.deps + extra_deps + stdrefs,
+            keyfile = ctx.file.keyfile,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,
             srcs = ctx.files.srcs + [ctx.file._nunit_shim],
@@ -63,6 +64,10 @@ csharp_nunit_test = rule(
         "analyzers": attr.label_list(
             doc = "A list of analyzer references.",
             providers = AnyTargetFramework,
+        ),
+        "keyfile": attr.label(
+            doc = "The key file used to sign the assembly with a strong name.",
+            allow_single_file = True,
         ),
         "langversion": attr.string(
             doc = "The version string for the C# language.",


### PR DESCRIPTION
Allows the user to build a strong-named assembly by specifying
a label (can be a single file) to a key file.