### PR TITLE
Moving csharp_library to have a single file in returned DefaultInfo

### DIFF
--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -34,7 +34,8 @@ def _library_impl(ctx):
 
     result = providers.values()
     result.append(DefaultInfo(
-        files = depset([result[0].out, result[0].refout, result[0].pdb]),
+        files = depset([result[0].out]),
+        default_runfiles = ctx.runfiles(files = [result[0].pdb]),
     ))
 
     return result


### PR DESCRIPTION
This allows dependent rules to easily use `csharp_library` rules for
things like copying files to another output location. Having multiple
files returned makes such a thing difficult.