### PR TITLE
Replace dotnet runtime with SDK

### DIFF
--- a/csharp/private/build-tools.BUILD
+++ b/csharp/private/build-tools.BUILD
@@ -1,4 +1,0 @@
-exports_files(
-    glob(["tasks/netcoreapp2.1/bincore/**/*"]),
-    visibility = ["//visibility:public"],
-)

--- a/csharp/private/repositories.bzl
+++ b/csharp/private/repositories.bzl
@@ -3,14 +3,6 @@ load(":macros/nuget.bzl", "nuget_package")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def csharp_repositories():
-    nuget_package(
-        name = "csharp-build-tools",
-        package = "Microsoft.Net.Compilers.Toolset",
-        version = "3.1.1",
-        sha256 = "078e88a3f347e1428868cfd091634489f385379069e85a6707184ac07da9d481",
-        build_file = "@d2l_rules_csharp//csharp/private:build-tools.BUILD",
-    )
-
     _net_workspace()
 
     create_net_workspace()
@@ -31,7 +23,7 @@ def csharp_repositories():
     )
 
     # We need the .NET Core runtime, sdk and compiler for our current OS,
-    # so that we can run the .NET core build of the compiler (from @csharp-build-tools).
+    # so that we can run the .NET core build of the compiler.
 
     _download_dotnet(
         os = "windows",

--- a/csharp/private/repositories.bzl
+++ b/csharp/private/repositories.bzl
@@ -30,26 +30,25 @@ def csharp_repositories():
         sha256 = "62b67516a08951a20b12b02e5d20b5045edbb687c3aabe9170286ec5bb9000a1",
     )
 
-    # We need the .NET Core runtime for whatever OS where executing our build
-    # on so that we can run the .NET core build of the compiler (from
-    # @csharp-build-tools).
+    # We need the .NET Core runtime, sdk and compiler for our current OS,
+    # so that we can run the .NET core build of the compiler (from @csharp-build-tools).
 
-    _download_runtime(
+    _download_dotnet(
         os = "windows",
-        url = "https://download.visualstudio.microsoft.com/download/pr/f15b7c04-2900-4a14-9c01-ccd66a4323cc/17a6bbd44f0d0a85d219dd9e166a89ca/dotnet-runtime-3.0.0-win-x64.zip",
-        hash = "60ba0e6ed7ae18a0186e71d18c38c013355b1fadc5fb053f40e5af5e33fdcd97",
+        url = "https://download.visualstudio.microsoft.com/download/pr/a24f4f34-ada1-433a-a437-5bc85fc2576a/7e886d06729949c15c96fe7e70faa8ae/dotnet-sdk-3.0.100-win-x64.zip",
+        hash = "faf8a92a523558e1659a6f9750c86610fe8430430f58099ccc659b83e3eee1bf",
     )
 
-    _download_runtime(
+    _download_dotnet(
         os = "linux",
-        url = "https://download.visualstudio.microsoft.com/download/pr/a5ff9cbb-d558-49d1-9fd2-410cb1c8b095/a940644f4133b81446cb3733a620983a/dotnet-runtime-3.0.0-linux-x64.tar.gz",
-        hash = "dea07b9c3cb102c042f3c4b9a500347bdbf214f03e78dfe9738de974544fffa1",
+        url = "https://download.visualstudio.microsoft.com/download/pr/886b4a4c-30af-454b-8bec-81c72b7b4e1f/d1a0c8de9abb36d8535363ede4a15de6/dotnet-sdk-3.0.100-linux-x64.tar.gz",
+        hash = "12098fe29d5c857fd6093b1fd63eda9f91b92798e3748fcedc0e0727f1ac01c2",
     )
 
-    _download_runtime(
+    _download_dotnet(
         os = "osx",
-        url = "https://download.visualstudio.microsoft.com/download/pr/68123d89-73c0-40b0-ba9b-93667c25663b/001f66f8ec4666421acc16f74209aa99/dotnet-runtime-3.0.0-osx-x64.tar.gz",
-        hash = "29799b7f40bc43d14f92ed6cd4d8eef9283f5b45cb8b3d49816c63e557958b81",
+        url = "https://download.visualstudio.microsoft.com/download/pr/b9251194-4118-41cb-ae05-6763fb002e5d/1d398b4e97069fa4968628080b617587/dotnet-sdk-3.0.100-osx-x64.tar.gz",
+        hash = "f0f8af049e0ecbeea9c9c37c16679d6fc2cd4c165510b00e3fad3cd8d0fe0160",
     )
 
 def csharp_register_toolchains():
@@ -59,9 +58,9 @@ def csharp_register_toolchains():
         "@d2l_rules_csharp//csharp/private:csharp_osx_toolchain",
     )
 
-def _download_runtime(os, url, hash):
+def _download_dotnet(os, url, hash):
     http_archive(
-        name = "netcore-runtime-%s" % os,
+        name = "netcore-sdk-%s" % os,
         urls = [url],
         sha256 = hash,
         build_file = "@d2l_rules_csharp//csharp/private:runtime.BUILD",

--- a/csharp/private/runtime.BUILD
+++ b/csharp/private/runtime.BUILD
@@ -6,6 +6,10 @@ exports_files(
     glob([
         "host/**/*",
         "shared/**/*",
+    ]) +
+    # csharp compiler: csc
+    glob([
+        "sdk/3.0.100/Roslyn/bincore/**/*",
     ]),
     visibility = ["//visibility:public"],
 )

--- a/csharp/private/toolchains.bzl
+++ b/csharp/private/toolchains.bzl
@@ -28,8 +28,8 @@ csharp_toolchain = rule(
 def configure_toolchain(os, exe = "dotnet"):
     csharp_toolchain(
         name = "csharp_x86_64-" + os,
-        runtime = "@netcore-runtime-%s//:%s" % (os, exe),
-        compiler = "@csharp-build-tools//:tasks/netcoreapp2.1/bincore/csc.dll",
+        runtime = "@netcore-sdk-%s//:%s" % (os, exe),
+        compiler = "@netcore-sdk-%s//:sdk/3.0.100/Roslyn/bincore/csc.dll" % (os),
     )
 
     native.toolchain(


### PR DESCRIPTION
ResX compilation works by creating a `.csproj` with the resx file as an embedded resource. When compiled (using GenerateResourceTask), it will create the `.resources` file that can then be embedded in the csharp lib/binary. To compile the csproj, we need the dotnet sdk.

Downloading the dotnet SDK on windows (`dotnet-sdk-windows`) takes around 86 seconds, and goes from ~45 MB (runtime + compiler) to ~110-150 MB (depending on OS).

Related to #10 and #96 