### PR TITLE
Upgrade the Dotnet SDK to 3.1.100 from 3.0.100

### DIFF
--- a/csharp/private/repositories.bzl
+++ b/csharp/private/repositories.bzl
@@ -1,3 +1,4 @@
+load(":sdk.bzl", "DOTNET_SDK")
 load(":rules/create_net_workspace.bzl", "create_net_workspace")
 load(":macros/nuget.bzl", "nuget_package")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -27,20 +28,20 @@ def csharp_repositories():
 
     _download_dotnet(
         os = "windows",
-        url = "https://download.visualstudio.microsoft.com/download/pr/a24f4f34-ada1-433a-a437-5bc85fc2576a/7e886d06729949c15c96fe7e70faa8ae/dotnet-sdk-3.0.100-win-x64.zip",
-        hash = "faf8a92a523558e1659a6f9750c86610fe8430430f58099ccc659b83e3eee1bf",
+        url = DOTNET_SDK["windows"]["url"],
+        hash = DOTNET_SDK["windows"]["hash"],
     )
 
     _download_dotnet(
         os = "linux",
-        url = "https://download.visualstudio.microsoft.com/download/pr/886b4a4c-30af-454b-8bec-81c72b7b4e1f/d1a0c8de9abb36d8535363ede4a15de6/dotnet-sdk-3.0.100-linux-x64.tar.gz",
-        hash = "12098fe29d5c857fd6093b1fd63eda9f91b92798e3748fcedc0e0727f1ac01c2",
+        url = DOTNET_SDK["linux"]["url"],
+        hash = DOTNET_SDK["linux"]["hash"],
     )
 
     _download_dotnet(
         os = "osx",
-        url = "https://download.visualstudio.microsoft.com/download/pr/b9251194-4118-41cb-ae05-6763fb002e5d/1d398b4e97069fa4968628080b617587/dotnet-sdk-3.0.100-osx-x64.tar.gz",
-        hash = "f0f8af049e0ecbeea9c9c37c16679d6fc2cd4c165510b00e3fad3cd8d0fe0160",
+        url = DOTNET_SDK["osx"]["url"],
+        hash = DOTNET_SDK["osx"]["hash"],
     )
 
 def csharp_register_toolchains():

--- a/csharp/private/runtime.BUILD
+++ b/csharp/private/runtime.BUILD
@@ -14,7 +14,7 @@ exports_files(
     ]) +
     # csharp compiler: csc
     glob([
-        "sdk/3.0.100/Roslyn/bincore/**/*",
+        "sdk/**/Roslyn/bincore/**/*",
     ]),
     visibility = ["//visibility:public"],
 )

--- a/csharp/private/sdk.bzl
+++ b/csharp/private/sdk.bzl
@@ -1,0 +1,19 @@
+# DotNET SDK Download URLs
+# These are the URLs to download the .NET SDKs for each of the support operating systems.
+#
+# You can get the latest URLs from here:
+#   https://dotnet.microsoft.com/download/dotnet-core
+DOTNET_SDK = {
+    "windows": {
+        "url": "https://download.visualstudio.microsoft.com/download/pr/a24f4f34-ada1-433a-a437-5bc85fc2576a/7e886d06729949c15c96fe7e70faa8ae/dotnet-sdk-3.0.100-win-x64.zip",
+        "hash": "faf8a92a523558e1659a6f9750c86610fe8430430f58099ccc659b83e3eee1bf",
+    },
+    "linux": {
+        "url": "https://download.visualstudio.microsoft.com/download/pr/886b4a4c-30af-454b-8bec-81c72b7b4e1f/d1a0c8de9abb36d8535363ede4a15de6/dotnet-sdk-3.0.100-linux-x64.tar.gz",
+        "hash": "12098fe29d5c857fd6093b1fd63eda9f91b92798e3748fcedc0e0727f1ac01c2",
+    },
+    "osx": {
+        "url": "https://download.visualstudio.microsoft.com/download/pr/b9251194-4118-41cb-ae05-6763fb002e5d/1d398b4e97069fa4968628080b617587/dotnet-sdk-3.0.100-osx-x64.tar.gz",
+        "hash": "f0f8af049e0ecbeea9c9c37c16679d6fc2cd4c165510b00e3fad3cd8d0fe0160",
+    },
+}

--- a/csharp/private/sdk.bzl
+++ b/csharp/private/sdk.bzl
@@ -3,17 +3,18 @@
 #
 # You can get the latest URLs from here:
 #   https://dotnet.microsoft.com/download/dotnet-core
+DOTNET_SDK_VERSION="3.1.100"
 DOTNET_SDK = {
     "windows": {
-        "url": "https://download.visualstudio.microsoft.com/download/pr/a24f4f34-ada1-433a-a437-5bc85fc2576a/7e886d06729949c15c96fe7e70faa8ae/dotnet-sdk-3.0.100-win-x64.zip",
-        "hash": "faf8a92a523558e1659a6f9750c86610fe8430430f58099ccc659b83e3eee1bf",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/28a2c4ff-6154-473b-bd51-c62c76171551/ea47eab2219f323596c039b3b679c3d6/dotnet-sdk-3.1.100-win-x64.zip",
+        "hash": "abcd034b230365d9454459e271e118a851969d82516b1529ee0bfea07f7aae52",
     },
     "linux": {
-        "url": "https://download.visualstudio.microsoft.com/download/pr/886b4a4c-30af-454b-8bec-81c72b7b4e1f/d1a0c8de9abb36d8535363ede4a15de6/dotnet-sdk-3.0.100-linux-x64.tar.gz",
-        "hash": "12098fe29d5c857fd6093b1fd63eda9f91b92798e3748fcedc0e0727f1ac01c2",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/d731f991-8e68-4c7c-8ea0-fad5605b077a/49497b5420eecbd905158d86d738af64/dotnet-sdk-3.1.100-linux-x64.tar.gz",
+        "hash": "3687b2a150cd5fef6d60a4693b4166994f32499c507cd04f346b6dda38ecdc46",
     },
     "osx": {
-        "url": "https://download.visualstudio.microsoft.com/download/pr/b9251194-4118-41cb-ae05-6763fb002e5d/1d398b4e97069fa4968628080b617587/dotnet-sdk-3.0.100-osx-x64.tar.gz",
-        "hash": "f0f8af049e0ecbeea9c9c37c16679d6fc2cd4c165510b00e3fad3cd8d0fe0160",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/bea99127-a762-4f9e-aac8-542ad8aa9a94/afb5af074b879303b19c6069e9e8d75f/dotnet-sdk-3.1.100-osx-x64.tar.gz",
+        "hash": "b38e6f8935d4b82b283d85c6b83cd24b5253730bab97e0e5e6f4c43e2b741aab",
     },
 }

--- a/csharp/private/sdk.bzl
+++ b/csharp/private/sdk.bzl
@@ -1,5 +1,5 @@
 # DotNET SDK Download URLs
-# These are the URLs to download the .NET SDKs for each of the support operating systems.
+# These are the URLs to download the .NET SDKs for each of the supported operating systems.
 #
 # You can get the latest URLs from here:
 #   https://dotnet.microsoft.com/download/dotnet-core

--- a/csharp/private/toolchains.bzl
+++ b/csharp/private/toolchains.bzl
@@ -1,3 +1,5 @@
+load(":sdk.bzl", "DOTNET_SDK_VERSION")
+
 def _csharp_toolchain_impl(ctx):
     return [
         platform_common.ToolchainInfo(
@@ -29,7 +31,7 @@ def configure_toolchain(os, exe = "dotnetw"):
     csharp_toolchain(
         name = "csharp_x86_64-" + os,
         runtime = "@netcore-sdk-%s//:%s" % (os, exe),
-        compiler = "@netcore-sdk-%s//:sdk/3.0.100/Roslyn/bincore/csc.dll" % (os),
+        compiler = "@netcore-sdk-%s//:sdk/%s/Roslyn/bincore/csc.dll" % (os, DOTNET_SDK_VERSION),
     )
 
     native.toolchain(


### PR DESCRIPTION
Upgrade to the latest version of the DotNET SDK.

You can see the release notes [here](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.0/3.1.0.md) (download path [here](https://dotnet.microsoft.com/download/dotnet-core/3.1))

Additionally refactored the SDK URLs and version information into the file `sdk.bzl`, so in the future it is easier to upgrade this dependency.