### PR TITLE
Upgrade to latest bazel version in CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,5 @@
 ---
-bazel: 1.1.0
+bazel: 1.2.1
 tasks:
   examples-windows:
     name: Examples on Windows


### PR DESCRIPTION
Upgrade to the latest version of bazel in CI. This is related to the discussion in #101 about pinning vs. latest upgrading of the version of bazel.

There is a [fix](https://github.com/bazelbuild/bazel/commit/ceadf0a063cb97c32aced143d2447781d1dafc38) that may be of use in the development of ResX compilation, as that is using runfiles a lot for its compilation.
