### PR TITLE
Resolve segmentation error with dotnet wrapper

### DIFF
--- a/csharp/private/wrappers/dotnet.cc
+++ b/csharp/private/wrappers/dotnet.cc
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
 
   // dotnet wants this to either be dotnet or dotnet.exe but doesn't have a
   // preference otherwise.
-  auto dotnet_argv = new char*[argc];
+  auto dotnet_argv = new char*[argc + 1];
   dotnet_argv[0] = (char*)"dotnet";
   for (int i = 1; i < argc; i++) {
     dotnet_argv[i] = argv[i];


### PR DESCRIPTION
The issue was an incorrect array size for the copied arguments. The array was set to size `argc`, but then an element outside of those bounds was being setting `nullptr`.

Tested by running the code over and over and over:
```bash
for i in {1..15}; do bazel clean && bazel build ///resgen:hello; done
```

Resolves #107 

I'll sum up my emotions as such:
![image](https://user-images.githubusercontent.com/3331589/70275507-45a44b00-177c-11ea-9edc-24bd60e3ca76.png)

