### PR TITLE
Fix formatting inconsistencies in the code using buildifier

### DIFF
--- a/csharp/private/BUILD
+++ b/csharp/private/BUILD
@@ -1,6 +1,9 @@
 load(":toolchains.bzl", "configure_toolchain")
 
-exports_files(["nunit/shim.cs", "wrappers/dotnet.cc"])
+exports_files([
+    "nunit/shim.cs",
+    "wrappers/dotnet.cc",
+])
 
 toolchain_type(name = "toolchain_type")
 

--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -58,7 +58,6 @@ def AssemblyAction(
         target,
         target_framework,
         toolchain):
-
     out_file_name = name if out == "" else out
     out_dir = "bazelout/" + target_framework
     out_ext = "dll" if target == "library" else "exe"
@@ -153,9 +152,10 @@ def AssemblyAction(
     # spill to a "response file" when the argument list gets too big (Bazel
     # makes that call based on limitations of the OS).
     args.set_param_file_format("multiline")
+
     # Our wrapper uses _spawnv to launch dotnet, and that has a command line limit
     # of 1024 bytes, so always use a param file.
-    args.use_param_file("@%s", use_always=True)
+    args.use_param_file("@%s", use_always = True)
 
     direct_inputs = srcs + resources + analyzer_assemblies + additionalfiles + [toolchain.compiler]
     direct_inputs += [keyfile] if keyfile else []
@@ -189,5 +189,5 @@ def AssemblyAction(
         deps = deps,
         transitive_refs = refs,
         transitive_runfiles = runfiles,
-        actual_tfm = target_framework
+        actual_tfm = target_framework,
     )

--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -81,7 +81,7 @@ def fill_in_missing_frameworks(providers):
         # nested loop isn't bad.
         # Order by providers that didn't "cross the netstandard boundary" so
         # newer netstandard will be preferred, if applicable
-        for (base, compatible_tfm) in sorted([(providers[compatible_tfm], compatible_tfm) for compatible_tfm in FrameworkCompatibility[tfm] if compatible_tfm in providers], key=_get_provided_by_netstandard):
+        for (base, compatible_tfm) in sorted([(providers[compatible_tfm], compatible_tfm) for compatible_tfm in FrameworkCompatibility[tfm] if compatible_tfm in providers], key = _get_provided_by_netstandard):
             # Copy the output from the compatible tfm, re-resolving the deps
             (refs, runfiles, native_dlls) = collect_transitive_info(base.deps, tfm)
             providers[tfm] = CSharpAssembly[tfm](
@@ -92,7 +92,7 @@ def fill_in_missing_frameworks(providers):
                 deps = base.deps,
                 transitive_refs = refs,
                 transitive_runfiles = runfiles,
-                actual_tfm = base.actual_tfm
+                actual_tfm = base.actual_tfm,
             )
             break
 

--- a/csharp/private/macros/setup_basic_nuget_package.bzl
+++ b/csharp/private/macros/setup_basic_nuget_package.bzl
@@ -47,7 +47,7 @@ def setup_basic_nuget_package():
     dlls = native.glob(["lib/*/*.dll"])
     pdbs = native.glob(["lib/*/*.pdb"])
 
-    has_pdb = { (pdb[:-3] + "dll"): 1 for pdb in pdbs }
+    has_pdb = {(pdb[:-3] + "dll"): 1 for pdb in pdbs}
 
     # Map from lib name to dict from tfm to target name
     imports = {}

--- a/csharp/private/net/BUILD
+++ b/csharp/private/net/BUILD
@@ -14,11 +14,11 @@ import_multiframework_library(
     net471 = "@net471//:StandardReferences",
     net472 = "@net472//:StandardReferences",
     net48 = "@net48//:StandardReferences",
-    netstandard2_0 = "@NetStandard.Library//:StandardReferences",
-    netstandard2_1 = "@NetStandard.Library.Ref//:StandardReferences",
     netcoreapp2_1 = "@netcoreapp2.1//:StandardReferences",
     netcoreapp2_2 = "@netcoreapp2.2//:StandardReferences",
     netcoreapp3_0 = "@netcoreapp3.0//:StandardReferences",
+    netstandard2_0 = "@NetStandard.Library//:StandardReferences",
+    netstandard2_1 = "@NetStandard.Library.Ref//:StandardReferences",
     visibility = ["//visibility:public"],
 )
 
@@ -380,11 +380,11 @@ import_multiframework_library(
     net471 = "@net471//:Microsoft.Win32.Primitives",
     net472 = "@net472//:Microsoft.Win32.Primitives",
     net48 = "@net48//:Microsoft.Win32.Primitives",
-    netstandard2_0 = "@NetStandard.Library//:Microsoft.Win32.Primitives",
-    netstandard2_1 = "@NetStandard.Library.Ref//:Microsoft.Win32.Primitives",
     netcoreapp2_1 = "@netcoreapp2.1//:Microsoft.Win32.Primitives",
     netcoreapp2_2 = "@netcoreapp2.2//:Microsoft.Win32.Primitives",
     netcoreapp3_0 = "@netcoreapp3.0//:Microsoft.Win32.Primitives",
+    netstandard2_0 = "@NetStandard.Library//:Microsoft.Win32.Primitives",
+    netstandard2_1 = "@NetStandard.Library.Ref//:Microsoft.Win32.Primitives",
     visibility = ["//visibility:public"],
 )
 
@@ -402,11 +402,11 @@ import_multiframework_library(
     net471 = "@net471//:mscorlib",
     net472 = "@net472//:mscorlib",
     net48 = "@net48//:mscorlib",
-    netstandard2_0 = "@NetStandard.Library//:mscorlib",
-    netstandard2_1 = "@NetStandard.Library.Ref//:mscorlib",
     netcoreapp2_1 = "@netcoreapp2.1//:mscorlib",
     netcoreapp2_2 = "@netcoreapp2.2//:mscorlib",
     netcoreapp3_0 = "@netcoreapp3.0//:mscorlib",
+    netstandard2_0 = "@NetStandard.Library//:mscorlib",
+    netstandard2_1 = "@NetStandard.Library.Ref//:mscorlib",
     visibility = ["//visibility:public"],
 )
 
@@ -415,11 +415,11 @@ import_multiframework_library(
     net471 = "@net471//:netstandard",
     net472 = "@net472//:netstandard",
     net48 = "@net48//:netstandard",
-    netstandard2_0 = "@NetStandard.Library//:netstandard",
-    netstandard2_1 = "@NetStandard.Library.Ref//:netstandard",
     netcoreapp2_1 = "@netcoreapp2.1//:netstandard",
     netcoreapp2_2 = "@netcoreapp2.2//:netstandard",
     netcoreapp3_0 = "@netcoreapp3.0//:netstandard",
+    netstandard2_0 = "@NetStandard.Library//:netstandard",
+    netstandard2_1 = "@NetStandard.Library.Ref//:netstandard",
     visibility = ["//visibility:public"],
 )
 
@@ -614,11 +614,11 @@ import_multiframework_library(
     net471 = "@net471//:System",
     net472 = "@net472//:System",
     net48 = "@net48//:System",
-    netstandard2_0 = "@NetStandard.Library//:System",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System",
     netcoreapp2_1 = "@netcoreapp2.1//:System",
     netcoreapp2_2 = "@netcoreapp2.2//:System",
     netcoreapp3_0 = "@netcoreapp3.0//:System",
+    netstandard2_0 = "@NetStandard.Library//:System",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System",
     visibility = ["//visibility:public"],
 )
 
@@ -723,20 +723,20 @@ import_multiframework_library(
     net471 = "@net471//:System.AppContext",
     net472 = "@net472//:System.AppContext",
     net48 = "@net48//:System.AppContext",
-    netstandard2_0 = "@NetStandard.Library//:System.AppContext",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.AppContext",
     netcoreapp2_1 = "@netcoreapp2.1//:System.AppContext",
     netcoreapp2_2 = "@netcoreapp2.2//:System.AppContext",
     netcoreapp3_0 = "@netcoreapp3.0//:System.AppContext",
+    netstandard2_0 = "@NetStandard.Library//:System.AppContext",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.AppContext",
     visibility = ["//visibility:public"],
 )
 
 import_multiframework_library(
     name = "System.Buffers",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Buffers",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Buffers",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Buffers",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Buffers",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Buffers",
     visibility = ["//visibility:public"],
 )
 
@@ -752,11 +752,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Collections",
     net472 = "@net472//:System.Collections",
     net48 = "@net48//:System.Collections",
-    netstandard2_0 = "@NetStandard.Library//:System.Collections",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Collections",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Collections",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Collections",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Collections",
+    netstandard2_0 = "@NetStandard.Library//:System.Collections",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Collections",
     visibility = ["//visibility:public"],
 )
 
@@ -772,11 +772,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Collections.Concurrent",
     net472 = "@net472//:System.Collections.Concurrent",
     net48 = "@net48//:System.Collections.Concurrent",
-    netstandard2_0 = "@NetStandard.Library//:System.Collections.Concurrent",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Collections.Concurrent",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Collections.Concurrent",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Collections.Concurrent",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Collections.Concurrent",
+    netstandard2_0 = "@NetStandard.Library//:System.Collections.Concurrent",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Collections.Concurrent",
     visibility = ["//visibility:public"],
 )
 
@@ -793,11 +793,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Collections.NonGeneric",
     net472 = "@net472//:System.Collections.NonGeneric",
     net48 = "@net48//:System.Collections.NonGeneric",
-    netstandard2_0 = "@NetStandard.Library//:System.Collections.NonGeneric",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Collections.NonGeneric",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Collections.NonGeneric",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Collections.NonGeneric",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Collections.NonGeneric",
+    netstandard2_0 = "@NetStandard.Library//:System.Collections.NonGeneric",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Collections.NonGeneric",
     visibility = ["//visibility:public"],
 )
 
@@ -806,11 +806,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Collections.Specialized",
     net472 = "@net472//:System.Collections.Specialized",
     net48 = "@net48//:System.Collections.Specialized",
-    netstandard2_0 = "@NetStandard.Library//:System.Collections.Specialized",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Collections.Specialized",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Collections.Specialized",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Collections.Specialized",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Collections.Specialized",
+    netstandard2_0 = "@NetStandard.Library//:System.Collections.Specialized",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Collections.Specialized",
     visibility = ["//visibility:public"],
 )
 
@@ -826,11 +826,11 @@ import_multiframework_library(
     net471 = "@net471//:System.ComponentModel",
     net472 = "@net472//:System.ComponentModel",
     net48 = "@net48//:System.ComponentModel",
-    netstandard2_0 = "@NetStandard.Library//:System.ComponentModel",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.ComponentModel",
     netcoreapp2_1 = "@netcoreapp2.1//:System.ComponentModel",
     netcoreapp2_2 = "@netcoreapp2.2//:System.ComponentModel",
     netcoreapp3_0 = "@netcoreapp3.0//:System.ComponentModel",
+    netstandard2_0 = "@NetStandard.Library//:System.ComponentModel",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.ComponentModel",
     visibility = ["//visibility:public"],
 )
 
@@ -916,11 +916,11 @@ import_multiframework_library(
     net471 = "@net471//:System.ComponentModel.EventBasedAsync",
     net472 = "@net472//:System.ComponentModel.EventBasedAsync",
     net48 = "@net48//:System.ComponentModel.EventBasedAsync",
-    netstandard2_0 = "@NetStandard.Library//:System.ComponentModel.EventBasedAsync",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.ComponentModel.EventBasedAsync",
     netcoreapp2_1 = "@netcoreapp2.1//:System.ComponentModel.EventBasedAsync",
     netcoreapp2_2 = "@netcoreapp2.2//:System.ComponentModel.EventBasedAsync",
     netcoreapp3_0 = "@netcoreapp3.0//:System.ComponentModel.EventBasedAsync",
+    netstandard2_0 = "@NetStandard.Library//:System.ComponentModel.EventBasedAsync",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.ComponentModel.EventBasedAsync",
     visibility = ["//visibility:public"],
 )
 
@@ -929,11 +929,11 @@ import_multiframework_library(
     net471 = "@net471//:System.ComponentModel.Primitives",
     net472 = "@net472//:System.ComponentModel.Primitives",
     net48 = "@net48//:System.ComponentModel.Primitives",
-    netstandard2_0 = "@NetStandard.Library//:System.ComponentModel.Primitives",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.ComponentModel.Primitives",
     netcoreapp2_1 = "@netcoreapp2.1//:System.ComponentModel.Primitives",
     netcoreapp2_2 = "@netcoreapp2.2//:System.ComponentModel.Primitives",
     netcoreapp3_0 = "@netcoreapp3.0//:System.ComponentModel.Primitives",
+    netstandard2_0 = "@NetStandard.Library//:System.ComponentModel.Primitives",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.ComponentModel.Primitives",
     visibility = ["//visibility:public"],
 )
 
@@ -942,11 +942,11 @@ import_multiframework_library(
     net471 = "@net471//:System.ComponentModel.TypeConverter",
     net472 = "@net472//:System.ComponentModel.TypeConverter",
     net48 = "@net48//:System.ComponentModel.TypeConverter",
-    netstandard2_0 = "@NetStandard.Library//:System.ComponentModel.TypeConverter",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.ComponentModel.TypeConverter",
     netcoreapp2_1 = "@netcoreapp2.1//:System.ComponentModel.TypeConverter",
     netcoreapp2_2 = "@netcoreapp2.2//:System.ComponentModel.TypeConverter",
     netcoreapp3_0 = "@netcoreapp3.0//:System.ComponentModel.TypeConverter",
+    netstandard2_0 = "@NetStandard.Library//:System.ComponentModel.TypeConverter",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.ComponentModel.TypeConverter",
     visibility = ["//visibility:public"],
 )
 
@@ -992,11 +992,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Console",
     net472 = "@net472//:System.Console",
     net48 = "@net48//:System.Console",
-    netstandard2_0 = "@NetStandard.Library//:System.Console",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Console",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Console",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Console",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Console",
+    netstandard2_0 = "@NetStandard.Library//:System.Console",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Console",
     visibility = ["//visibility:public"],
 )
 
@@ -1013,11 +1013,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Core",
     net472 = "@net472//:System.Core",
     net48 = "@net48//:System.Core",
-    netstandard2_0 = "@NetStandard.Library//:System.Core",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Core",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Core",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Core",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Core",
+    netstandard2_0 = "@NetStandard.Library//:System.Core",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Core",
     visibility = ["//visibility:public"],
 )
 
@@ -1035,11 +1035,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Data",
     net472 = "@net472//:System.Data",
     net48 = "@net48//:System.Data",
-    netstandard2_0 = "@NetStandard.Library//:System.Data",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Data",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Data",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Data",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Data",
+    netstandard2_0 = "@NetStandard.Library//:System.Data",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Data",
     visibility = ["//visibility:public"],
 )
 
@@ -1048,11 +1048,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Data.Common",
     net472 = "@net472//:System.Data.Common",
     net48 = "@net48//:System.Data.Common",
-    netstandard2_0 = "@NetStandard.Library//:System.Data.Common",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Data.Common",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Data.Common",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Data.Common",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Data.Common",
+    netstandard2_0 = "@NetStandard.Library//:System.Data.Common",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Data.Common",
     visibility = ["//visibility:public"],
 )
 
@@ -1265,11 +1265,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.Contracts",
     net472 = "@net472//:System.Diagnostics.Contracts",
     net48 = "@net48//:System.Diagnostics.Contracts",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Contracts",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Contracts",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.Contracts",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.Contracts",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.Contracts",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Contracts",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Contracts",
     visibility = ["//visibility:public"],
 )
 
@@ -1285,11 +1285,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.Debug",
     net472 = "@net472//:System.Diagnostics.Debug",
     net48 = "@net48//:System.Diagnostics.Debug",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Debug",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Debug",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.Debug",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.Debug",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.Debug",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Debug",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Debug",
     visibility = ["//visibility:public"],
 )
 
@@ -1306,11 +1306,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.FileVersionInfo",
     net472 = "@net472//:System.Diagnostics.FileVersionInfo",
     net48 = "@net48//:System.Diagnostics.FileVersionInfo",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.FileVersionInfo",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.FileVersionInfo",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.FileVersionInfo",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.FileVersionInfo",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.FileVersionInfo",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.FileVersionInfo",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.FileVersionInfo",
     visibility = ["//visibility:public"],
 )
 
@@ -1319,11 +1319,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.Process",
     net472 = "@net472//:System.Diagnostics.Process",
     net48 = "@net48//:System.Diagnostics.Process",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Process",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Process",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.Process",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.Process",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.Process",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Process",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Process",
     visibility = ["//visibility:public"],
 )
 
@@ -1332,11 +1332,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.StackTrace",
     net472 = "@net472//:System.Diagnostics.StackTrace",
     net48 = "@net48//:System.Diagnostics.StackTrace",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.StackTrace",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.StackTrace",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.StackTrace",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.StackTrace",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.StackTrace",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.StackTrace",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.StackTrace",
     visibility = ["//visibility:public"],
 )
 
@@ -1345,11 +1345,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.TextWriterTraceListener",
     net472 = "@net472//:System.Diagnostics.TextWriterTraceListener",
     net48 = "@net48//:System.Diagnostics.TextWriterTraceListener",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.TextWriterTraceListener",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.TextWriterTraceListener",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.TextWriterTraceListener",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.TextWriterTraceListener",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.TextWriterTraceListener",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.TextWriterTraceListener",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.TextWriterTraceListener",
     visibility = ["//visibility:public"],
 )
 
@@ -1365,11 +1365,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.Tools",
     net472 = "@net472//:System.Diagnostics.Tools",
     net48 = "@net48//:System.Diagnostics.Tools",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Tools",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Tools",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.Tools",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.Tools",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.Tools",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Tools",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Tools",
     visibility = ["//visibility:public"],
 )
 
@@ -1378,11 +1378,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.TraceSource",
     net472 = "@net472//:System.Diagnostics.TraceSource",
     net48 = "@net48//:System.Diagnostics.TraceSource",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.TraceSource",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.TraceSource",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.TraceSource",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.TraceSource",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.TraceSource",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.TraceSource",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.TraceSource",
     visibility = ["//visibility:public"],
 )
 
@@ -1398,11 +1398,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Diagnostics.Tracing",
     net472 = "@net472//:System.Diagnostics.Tracing",
     net48 = "@net48//:System.Diagnostics.Tracing",
-    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Tracing",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Tracing",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Diagnostics.Tracing",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Diagnostics.Tracing",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Diagnostics.Tracing",
+    netstandard2_0 = "@NetStandard.Library//:System.Diagnostics.Tracing",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Diagnostics.Tracing",
     visibility = ["//visibility:public"],
 )
 
@@ -1470,11 +1470,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Drawing",
     net472 = "@net472//:System.Drawing",
     net48 = "@net48//:System.Drawing",
-    netstandard2_0 = "@NetStandard.Library//:System.Drawing",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Drawing",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Drawing",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Drawing",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Drawing",
+    netstandard2_0 = "@NetStandard.Library//:System.Drawing",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Drawing",
     visibility = ["//visibility:public"],
 )
 
@@ -1500,11 +1500,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Drawing.Primitives",
     net472 = "@net472//:System.Drawing.Primitives",
     net48 = "@net48//:System.Drawing.Primitives",
-    netstandard2_0 = "@NetStandard.Library//:System.Drawing.Primitives",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Drawing.Primitives",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Drawing.Primitives",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Drawing.Primitives",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Drawing.Primitives",
+    netstandard2_0 = "@NetStandard.Library//:System.Drawing.Primitives",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Drawing.Primitives",
     visibility = ["//visibility:public"],
 )
 
@@ -1532,11 +1532,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Dynamic.Runtime",
     net472 = "@net472//:System.Dynamic.Runtime",
     net48 = "@net48//:System.Dynamic.Runtime",
-    netstandard2_0 = "@NetStandard.Library//:System.Dynamic.Runtime",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Dynamic.Runtime",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Dynamic.Runtime",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Dynamic.Runtime",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Dynamic.Runtime",
+    netstandard2_0 = "@NetStandard.Library//:System.Dynamic.Runtime",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Dynamic.Runtime",
     visibility = ["//visibility:public"],
 )
 
@@ -1569,11 +1569,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Globalization",
     net472 = "@net472//:System.Globalization",
     net48 = "@net48//:System.Globalization",
-    netstandard2_0 = "@NetStandard.Library//:System.Globalization",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Globalization",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Globalization",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Globalization",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Globalization",
+    netstandard2_0 = "@NetStandard.Library//:System.Globalization",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Globalization",
     visibility = ["//visibility:public"],
 )
 
@@ -1582,11 +1582,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Globalization.Calendars",
     net472 = "@net472//:System.Globalization.Calendars",
     net48 = "@net48//:System.Globalization.Calendars",
-    netstandard2_0 = "@NetStandard.Library//:System.Globalization.Calendars",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Globalization.Calendars",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Globalization.Calendars",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Globalization.Calendars",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Globalization.Calendars",
+    netstandard2_0 = "@NetStandard.Library//:System.Globalization.Calendars",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Globalization.Calendars",
     visibility = ["//visibility:public"],
 )
 
@@ -1595,11 +1595,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Globalization.Extensions",
     net472 = "@net472//:System.Globalization.Extensions",
     net48 = "@net48//:System.Globalization.Extensions",
-    netstandard2_0 = "@NetStandard.Library//:System.Globalization.Extensions",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Globalization.Extensions",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Globalization.Extensions",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Globalization.Extensions",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Globalization.Extensions",
+    netstandard2_0 = "@NetStandard.Library//:System.Globalization.Extensions",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Globalization.Extensions",
     visibility = ["//visibility:public"],
 )
 
@@ -1662,11 +1662,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO",
     net472 = "@net472//:System.IO",
     net48 = "@net48//:System.IO",
-    netstandard2_0 = "@NetStandard.Library//:System.IO",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO",
+    netstandard2_0 = "@NetStandard.Library//:System.IO",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO",
     visibility = ["//visibility:public"],
 )
 
@@ -1682,11 +1682,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.Compression",
     net472 = "@net472//:System.IO.Compression",
     net48 = "@net48//:System.IO.Compression",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.Compression",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.Compression",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.Compression",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.Compression",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.Compression",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.Compression",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.Compression",
     visibility = ["//visibility:public"],
 )
 
@@ -1710,11 +1710,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.Compression.FileSystem",
     net472 = "@net472//:System.IO.Compression.FileSystem",
     net48 = "@net48//:System.IO.Compression.FileSystem",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.Compression.FileSystem",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.Compression.FileSystem",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.Compression.FileSystem",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.Compression.FileSystem",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.Compression.FileSystem",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.Compression.FileSystem",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.Compression.FileSystem",
     visibility = ["//visibility:public"],
 )
 
@@ -1723,11 +1723,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.Compression.ZipFile",
     net472 = "@net472//:System.IO.Compression.ZipFile",
     net48 = "@net48//:System.IO.Compression.ZipFile",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.Compression.ZipFile",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.Compression.ZipFile",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.Compression.ZipFile",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.Compression.ZipFile",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.Compression.ZipFile",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.Compression.ZipFile",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.Compression.ZipFile",
     visibility = ["//visibility:public"],
 )
 
@@ -1736,11 +1736,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.FileSystem",
     net472 = "@net472//:System.IO.FileSystem",
     net48 = "@net48//:System.IO.FileSystem",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.FileSystem",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.FileSystem",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.FileSystem",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.FileSystem",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.FileSystem",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.FileSystem",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.FileSystem",
     visibility = ["//visibility:public"],
 )
 
@@ -1749,11 +1749,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.FileSystem.DriveInfo",
     net472 = "@net472//:System.IO.FileSystem.DriveInfo",
     net48 = "@net48//:System.IO.FileSystem.DriveInfo",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.FileSystem.DriveInfo",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.FileSystem.DriveInfo",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.FileSystem.DriveInfo",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.FileSystem.DriveInfo",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.FileSystem.DriveInfo",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.FileSystem.DriveInfo",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.FileSystem.DriveInfo",
     visibility = ["//visibility:public"],
 )
 
@@ -1762,11 +1762,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.FileSystem.Primitives",
     net472 = "@net472//:System.IO.FileSystem.Primitives",
     net48 = "@net48//:System.IO.FileSystem.Primitives",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.FileSystem.Primitives",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.FileSystem.Primitives",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.FileSystem.Primitives",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.FileSystem.Primitives",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.FileSystem.Primitives",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.FileSystem.Primitives",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.FileSystem.Primitives",
     visibility = ["//visibility:public"],
 )
 
@@ -1775,11 +1775,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.FileSystem.Watcher",
     net472 = "@net472//:System.IO.FileSystem.Watcher",
     net48 = "@net48//:System.IO.FileSystem.Watcher",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.FileSystem.Watcher",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.FileSystem.Watcher",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.FileSystem.Watcher",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.FileSystem.Watcher",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.FileSystem.Watcher",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.FileSystem.Watcher",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.FileSystem.Watcher",
     visibility = ["//visibility:public"],
 )
 
@@ -1788,11 +1788,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.IsolatedStorage",
     net472 = "@net472//:System.IO.IsolatedStorage",
     net48 = "@net48//:System.IO.IsolatedStorage",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.IsolatedStorage",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.IsolatedStorage",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.IsolatedStorage",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.IsolatedStorage",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.IsolatedStorage",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.IsolatedStorage",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.IsolatedStorage",
     visibility = ["//visibility:public"],
 )
 
@@ -1817,11 +1817,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.MemoryMappedFiles",
     net472 = "@net472//:System.IO.MemoryMappedFiles",
     net48 = "@net48//:System.IO.MemoryMappedFiles",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.MemoryMappedFiles",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.MemoryMappedFiles",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.MemoryMappedFiles",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.MemoryMappedFiles",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.MemoryMappedFiles",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.MemoryMappedFiles",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.MemoryMappedFiles",
     visibility = ["//visibility:public"],
 )
 
@@ -1830,11 +1830,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.Pipes",
     net472 = "@net472//:System.IO.Pipes",
     net48 = "@net48//:System.IO.Pipes",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.Pipes",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.Pipes",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.Pipes",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.Pipes",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.Pipes",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.Pipes",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.Pipes",
     visibility = ["//visibility:public"],
 )
 
@@ -1843,11 +1843,11 @@ import_multiframework_library(
     net471 = "@net471//:System.IO.UnmanagedMemoryStream",
     net472 = "@net472//:System.IO.UnmanagedMemoryStream",
     net48 = "@net48//:System.IO.UnmanagedMemoryStream",
-    netstandard2_0 = "@NetStandard.Library//:System.IO.UnmanagedMemoryStream",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.UnmanagedMemoryStream",
     netcoreapp2_1 = "@netcoreapp2.1//:System.IO.UnmanagedMemoryStream",
     netcoreapp2_2 = "@netcoreapp2.2//:System.IO.UnmanagedMemoryStream",
     netcoreapp3_0 = "@netcoreapp3.0//:System.IO.UnmanagedMemoryStream",
+    netstandard2_0 = "@NetStandard.Library//:System.IO.UnmanagedMemoryStream",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.IO.UnmanagedMemoryStream",
     visibility = ["//visibility:public"],
 )
 
@@ -1863,11 +1863,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Linq",
     net472 = "@net472//:System.Linq",
     net48 = "@net48//:System.Linq",
-    netstandard2_0 = "@NetStandard.Library//:System.Linq",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Linq",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Linq",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Linq",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Linq",
+    netstandard2_0 = "@NetStandard.Library//:System.Linq",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Linq",
     visibility = ["//visibility:public"],
 )
 
@@ -1883,11 +1883,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Linq.Expressions",
     net472 = "@net472//:System.Linq.Expressions",
     net48 = "@net48//:System.Linq.Expressions",
-    netstandard2_0 = "@NetStandard.Library//:System.Linq.Expressions",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Linq.Expressions",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Linq.Expressions",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Linq.Expressions",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Linq.Expressions",
+    netstandard2_0 = "@NetStandard.Library//:System.Linq.Expressions",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Linq.Expressions",
     visibility = ["//visibility:public"],
 )
 
@@ -1903,11 +1903,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Linq.Parallel",
     net472 = "@net472//:System.Linq.Parallel",
     net48 = "@net48//:System.Linq.Parallel",
-    netstandard2_0 = "@NetStandard.Library//:System.Linq.Parallel",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Linq.Parallel",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Linq.Parallel",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Linq.Parallel",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Linq.Parallel",
+    netstandard2_0 = "@NetStandard.Library//:System.Linq.Parallel",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Linq.Parallel",
     visibility = ["//visibility:public"],
 )
 
@@ -1923,20 +1923,20 @@ import_multiframework_library(
     net471 = "@net471//:System.Linq.Queryable",
     net472 = "@net472//:System.Linq.Queryable",
     net48 = "@net48//:System.Linq.Queryable",
-    netstandard2_0 = "@NetStandard.Library//:System.Linq.Queryable",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Linq.Queryable",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Linq.Queryable",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Linq.Queryable",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Linq.Queryable",
+    netstandard2_0 = "@NetStandard.Library//:System.Linq.Queryable",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Linq.Queryable",
     visibility = ["//visibility:public"],
 )
 
 import_multiframework_library(
     name = "System.Memory",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Memory",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Memory",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Memory",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Memory",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Memory",
     visibility = ["//visibility:public"],
 )
 
@@ -2003,11 +2003,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net",
     net472 = "@net472//:System.Net",
     net48 = "@net48//:System.Net",
-    netstandard2_0 = "@NetStandard.Library//:System.Net",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net",
+    netstandard2_0 = "@NetStandard.Library//:System.Net",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net",
     visibility = ["//visibility:public"],
 )
 
@@ -2023,11 +2023,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.Http",
     net472 = "@net472//:System.Net.Http",
     net48 = "@net48//:System.Net.Http",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.Http",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Http",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.Http",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.Http",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.Http",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.Http",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Http",
     visibility = ["//visibility:public"],
 )
 
@@ -2075,11 +2075,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.NameResolution",
     net472 = "@net472//:System.Net.NameResolution",
     net48 = "@net48//:System.Net.NameResolution",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.NameResolution",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.NameResolution",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.NameResolution",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.NameResolution",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.NameResolution",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.NameResolution",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.NameResolution",
     visibility = ["//visibility:public"],
 )
 
@@ -2095,11 +2095,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.NetworkInformation",
     net472 = "@net472//:System.Net.NetworkInformation",
     net48 = "@net48//:System.Net.NetworkInformation",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.NetworkInformation",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.NetworkInformation",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.NetworkInformation",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.NetworkInformation",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.NetworkInformation",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.NetworkInformation",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.NetworkInformation",
     visibility = ["//visibility:public"],
 )
 
@@ -2108,11 +2108,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.Ping",
     net472 = "@net472//:System.Net.Ping",
     net48 = "@net48//:System.Net.Ping",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.Ping",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Ping",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.Ping",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.Ping",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.Ping",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.Ping",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Ping",
     visibility = ["//visibility:public"],
 )
 
@@ -2128,11 +2128,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.Primitives",
     net472 = "@net472//:System.Net.Primitives",
     net48 = "@net48//:System.Net.Primitives",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.Primitives",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Primitives",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.Primitives",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.Primitives",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.Primitives",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.Primitives",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Primitives",
     visibility = ["//visibility:public"],
 )
 
@@ -2148,11 +2148,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.Requests",
     net472 = "@net472//:System.Net.Requests",
     net48 = "@net48//:System.Net.Requests",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.Requests",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Requests",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.Requests",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.Requests",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.Requests",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.Requests",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Requests",
     visibility = ["//visibility:public"],
 )
 
@@ -2161,11 +2161,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.Security",
     net472 = "@net472//:System.Net.Security",
     net48 = "@net48//:System.Net.Security",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.Security",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Security",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.Security",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.Security",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.Security",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.Security",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Security",
     visibility = ["//visibility:public"],
 )
 
@@ -2182,11 +2182,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.Sockets",
     net472 = "@net472//:System.Net.Sockets",
     net48 = "@net48//:System.Net.Sockets",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.Sockets",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Sockets",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.Sockets",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.Sockets",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.Sockets",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.Sockets",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.Sockets",
     visibility = ["//visibility:public"],
 )
 
@@ -2207,11 +2207,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.WebHeaderCollection",
     net472 = "@net472//:System.Net.WebHeaderCollection",
     net48 = "@net48//:System.Net.WebHeaderCollection",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.WebHeaderCollection",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.WebHeaderCollection",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.WebHeaderCollection",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.WebHeaderCollection",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.WebHeaderCollection",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.WebHeaderCollection",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.WebHeaderCollection",
     visibility = ["//visibility:public"],
 )
 
@@ -2228,11 +2228,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.WebSockets",
     net472 = "@net472//:System.Net.WebSockets",
     net48 = "@net48//:System.Net.WebSockets",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.WebSockets",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.WebSockets",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.WebSockets",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.WebSockets",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.WebSockets",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.WebSockets",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.WebSockets",
     visibility = ["//visibility:public"],
 )
 
@@ -2241,11 +2241,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Net.WebSockets.Client",
     net472 = "@net472//:System.Net.WebSockets.Client",
     net48 = "@net48//:System.Net.WebSockets.Client",
-    netstandard2_0 = "@NetStandard.Library//:System.Net.WebSockets.Client",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.WebSockets.Client",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Net.WebSockets.Client",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Net.WebSockets.Client",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Net.WebSockets.Client",
+    netstandard2_0 = "@NetStandard.Library//:System.Net.WebSockets.Client",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Net.WebSockets.Client",
     visibility = ["//visibility:public"],
 )
 
@@ -2262,20 +2262,20 @@ import_multiframework_library(
     net471 = "@net471//:System.Numerics",
     net472 = "@net472//:System.Numerics",
     net48 = "@net48//:System.Numerics",
-    netstandard2_0 = "@NetStandard.Library//:System.Numerics",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Numerics",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Numerics",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Numerics",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Numerics",
+    netstandard2_0 = "@NetStandard.Library//:System.Numerics",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Numerics",
     visibility = ["//visibility:public"],
 )
 
 import_multiframework_library(
     name = "System.Numerics.Vectors",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Numerics.Vectors",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Numerics.Vectors",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Numerics.Vectors",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Numerics.Vectors",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Numerics.Vectors",
     visibility = ["//visibility:public"],
 )
 
@@ -2291,11 +2291,11 @@ import_multiframework_library(
     net471 = "@net471//:System.ObjectModel",
     net472 = "@net472//:System.ObjectModel",
     net48 = "@net48//:System.ObjectModel",
-    netstandard2_0 = "@NetStandard.Library//:System.ObjectModel",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.ObjectModel",
     netcoreapp2_1 = "@netcoreapp2.1//:System.ObjectModel",
     netcoreapp2_2 = "@netcoreapp2.2//:System.ObjectModel",
     netcoreapp3_0 = "@netcoreapp3.0//:System.ObjectModel",
+    netstandard2_0 = "@NetStandard.Library//:System.ObjectModel",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.ObjectModel",
     visibility = ["//visibility:public"],
 )
 
@@ -2327,11 +2327,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Reflection",
     net472 = "@net472//:System.Reflection",
     net48 = "@net48//:System.Reflection",
-    netstandard2_0 = "@NetStandard.Library//:System.Reflection",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Reflection",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Reflection",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Reflection",
+    netstandard2_0 = "@NetStandard.Library//:System.Reflection",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection",
     visibility = ["//visibility:public"],
 )
 
@@ -2352,10 +2352,10 @@ import_multiframework_library(
 
 import_multiframework_library(
     name = "System.Reflection.DispatchProxy",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.DispatchProxy",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Reflection.DispatchProxy",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Reflection.DispatchProxy",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Reflection.DispatchProxy",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.DispatchProxy",
     visibility = ["//visibility:public"],
 )
 
@@ -2371,10 +2371,10 @@ import_multiframework_library(
     net471 = "@net471//:System.Reflection.Emit",
     net472 = "@net472//:System.Reflection.Emit",
     net48 = "@net48//:System.Reflection.Emit",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Emit",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Reflection.Emit",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Reflection.Emit",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Reflection.Emit",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Emit",
     visibility = ["//visibility:public"],
 )
 
@@ -2390,10 +2390,10 @@ import_multiframework_library(
     net471 = "@net471//:System.Reflection.Emit.ILGeneration",
     net472 = "@net472//:System.Reflection.Emit.ILGeneration",
     net48 = "@net48//:System.Reflection.Emit.ILGeneration",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Emit.ILGeneration",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Reflection.Emit.ILGeneration",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Reflection.Emit.ILGeneration",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Reflection.Emit.ILGeneration",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Emit.ILGeneration",
     visibility = ["//visibility:public"],
 )
 
@@ -2409,10 +2409,10 @@ import_multiframework_library(
     net471 = "@net471//:System.Reflection.Emit.Lightweight",
     net472 = "@net472//:System.Reflection.Emit.Lightweight",
     net48 = "@net48//:System.Reflection.Emit.Lightweight",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Emit.Lightweight",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Reflection.Emit.Lightweight",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Reflection.Emit.Lightweight",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Reflection.Emit.Lightweight",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Emit.Lightweight",
     visibility = ["//visibility:public"],
 )
 
@@ -2428,11 +2428,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Reflection.Extensions",
     net472 = "@net472//:System.Reflection.Extensions",
     net48 = "@net48//:System.Reflection.Extensions",
-    netstandard2_0 = "@NetStandard.Library//:System.Reflection.Extensions",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Extensions",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Reflection.Extensions",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Reflection.Extensions",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Reflection.Extensions",
+    netstandard2_0 = "@NetStandard.Library//:System.Reflection.Extensions",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Extensions",
     visibility = ["//visibility:public"],
 )
 
@@ -2456,11 +2456,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Reflection.Primitives",
     net472 = "@net472//:System.Reflection.Primitives",
     net48 = "@net48//:System.Reflection.Primitives",
-    netstandard2_0 = "@NetStandard.Library//:System.Reflection.Primitives",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Primitives",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Reflection.Primitives",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Reflection.Primitives",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Reflection.Primitives",
+    netstandard2_0 = "@NetStandard.Library//:System.Reflection.Primitives",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Reflection.Primitives",
     visibility = ["//visibility:public"],
 )
 
@@ -2477,11 +2477,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Resources.Reader",
     net472 = "@net472//:System.Resources.Reader",
     net48 = "@net48//:System.Resources.Reader",
-    netstandard2_0 = "@NetStandard.Library//:System.Resources.Reader",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Resources.Reader",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Resources.Reader",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Resources.Reader",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Resources.Reader",
+    netstandard2_0 = "@NetStandard.Library//:System.Resources.Reader",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Resources.Reader",
     visibility = ["//visibility:public"],
 )
 
@@ -2497,11 +2497,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Resources.ResourceManager",
     net472 = "@net472//:System.Resources.ResourceManager",
     net48 = "@net48//:System.Resources.ResourceManager",
-    netstandard2_0 = "@NetStandard.Library//:System.Resources.ResourceManager",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Resources.ResourceManager",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Resources.ResourceManager",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Resources.ResourceManager",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Resources.ResourceManager",
+    netstandard2_0 = "@NetStandard.Library//:System.Resources.ResourceManager",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Resources.ResourceManager",
     visibility = ["//visibility:public"],
 )
 
@@ -2510,11 +2510,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Resources.Writer",
     net472 = "@net472//:System.Resources.Writer",
     net48 = "@net48//:System.Resources.Writer",
-    netstandard2_0 = "@NetStandard.Library//:System.Resources.Writer",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Resources.Writer",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Resources.Writer",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Resources.Writer",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Resources.Writer",
+    netstandard2_0 = "@NetStandard.Library//:System.Resources.Writer",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Resources.Writer",
     visibility = ["//visibility:public"],
 )
 
@@ -2530,11 +2530,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime",
     net472 = "@net472//:System.Runtime",
     net48 = "@net48//:System.Runtime",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime",
     visibility = ["//visibility:public"],
 )
 
@@ -2565,11 +2565,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.CompilerServices.VisualC",
     net472 = "@net472//:System.Runtime.CompilerServices.VisualC",
     net48 = "@net48//:System.Runtime.CompilerServices.VisualC",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.CompilerServices.VisualC",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.CompilerServices.VisualC",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.CompilerServices.VisualC",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.CompilerServices.VisualC",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.CompilerServices.VisualC",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.CompilerServices.VisualC",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.CompilerServices.VisualC",
     visibility = ["//visibility:public"],
 )
 
@@ -2601,11 +2601,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.Extensions",
     net472 = "@net472//:System.Runtime.Extensions",
     net48 = "@net48//:System.Runtime.Extensions",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Extensions",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Extensions",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.Extensions",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.Extensions",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.Extensions",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Extensions",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Extensions",
     visibility = ["//visibility:public"],
 )
 
@@ -2618,11 +2618,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.Handles",
     net472 = "@net472//:System.Runtime.Handles",
     net48 = "@net48//:System.Runtime.Handles",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Handles",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Handles",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.Handles",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.Handles",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.Handles",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Handles",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Handles",
     visibility = ["//visibility:public"],
 )
 
@@ -2638,11 +2638,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.InteropServices",
     net472 = "@net472//:System.Runtime.InteropServices",
     net48 = "@net48//:System.Runtime.InteropServices",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.InteropServices",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.InteropServices",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.InteropServices",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.InteropServices",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.InteropServices",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.InteropServices",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.InteropServices",
     visibility = ["//visibility:public"],
 )
 
@@ -2651,11 +2651,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.InteropServices.RuntimeInformation",
     net472 = "@net472//:System.Runtime.InteropServices.RuntimeInformation",
     net48 = "@net48//:System.Runtime.InteropServices.RuntimeInformation",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.InteropServices.RuntimeInformation",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.InteropServices.RuntimeInformation",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.InteropServices.RuntimeInformation",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.InteropServices.RuntimeInformation",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.InteropServices.RuntimeInformation",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.InteropServices.RuntimeInformation",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.InteropServices.RuntimeInformation",
     visibility = ["//visibility:public"],
 )
 
@@ -2703,11 +2703,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.Numerics",
     net472 = "@net472//:System.Runtime.Numerics",
     net48 = "@net48//:System.Runtime.Numerics",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Numerics",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Numerics",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.Numerics",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.Numerics",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.Numerics",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Numerics",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Numerics",
     visibility = ["//visibility:public"],
 )
 
@@ -2741,11 +2741,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.Serialization",
     net472 = "@net472//:System.Runtime.Serialization",
     net48 = "@net48//:System.Runtime.Serialization",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.Serialization",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.Serialization",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.Serialization",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization",
     visibility = ["//visibility:public"],
 )
 
@@ -2754,11 +2754,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.Serialization.Formatters",
     net472 = "@net472//:System.Runtime.Serialization.Formatters",
     net48 = "@net48//:System.Runtime.Serialization.Formatters",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization.Formatters",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization.Formatters",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.Serialization.Formatters",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.Serialization.Formatters",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.Serialization.Formatters",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization.Formatters",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization.Formatters",
     visibility = ["//visibility:public"],
 )
 
@@ -2791,11 +2791,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.Serialization.Json",
     net472 = "@net472//:System.Runtime.Serialization.Json",
     net48 = "@net48//:System.Runtime.Serialization.Json",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization.Json",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization.Json",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.Serialization.Json",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.Serialization.Json",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.Serialization.Json",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization.Json",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization.Json",
     visibility = ["//visibility:public"],
 )
 
@@ -2811,11 +2811,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.Serialization.Primitives",
     net472 = "@net472//:System.Runtime.Serialization.Primitives",
     net48 = "@net48//:System.Runtime.Serialization.Primitives",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization.Primitives",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization.Primitives",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.Serialization.Primitives",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.Serialization.Primitives",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.Serialization.Primitives",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization.Primitives",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization.Primitives",
     visibility = ["//visibility:public"],
 )
 
@@ -2831,11 +2831,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Runtime.Serialization.Xml",
     net472 = "@net472//:System.Runtime.Serialization.Xml",
     net48 = "@net48//:System.Runtime.Serialization.Xml",
-    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization.Xml",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization.Xml",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Runtime.Serialization.Xml",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Runtime.Serialization.Xml",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Runtime.Serialization.Xml",
+    netstandard2_0 = "@NetStandard.Library//:System.Runtime.Serialization.Xml",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Runtime.Serialization.Xml",
     visibility = ["//visibility:public"],
 )
 
@@ -2864,11 +2864,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Security.Claims",
     net472 = "@net472//:System.Security.Claims",
     net48 = "@net48//:System.Security.Claims",
-    netstandard2_0 = "@NetStandard.Library//:System.Security.Claims",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Claims",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Security.Claims",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Security.Claims",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Security.Claims",
+    netstandard2_0 = "@NetStandard.Library//:System.Security.Claims",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Claims",
     visibility = ["//visibility:public"],
 )
 
@@ -2877,11 +2877,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Security.Cryptography.Algorithms",
     net472 = "@net472//:System.Security.Cryptography.Algorithms",
     net48 = "@net48//:System.Security.Cryptography.Algorithms",
-    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.Algorithms",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.Algorithms",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Security.Cryptography.Algorithms",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Security.Cryptography.Algorithms",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Security.Cryptography.Algorithms",
+    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.Algorithms",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.Algorithms",
     visibility = ["//visibility:public"],
 )
 
@@ -2890,11 +2890,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Security.Cryptography.Csp",
     net472 = "@net472//:System.Security.Cryptography.Csp",
     net48 = "@net48//:System.Security.Cryptography.Csp",
-    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.Csp",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.Csp",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Security.Cryptography.Csp",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Security.Cryptography.Csp",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Security.Cryptography.Csp",
+    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.Csp",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.Csp",
     visibility = ["//visibility:public"],
 )
 
@@ -2903,11 +2903,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Security.Cryptography.Encoding",
     net472 = "@net472//:System.Security.Cryptography.Encoding",
     net48 = "@net48//:System.Security.Cryptography.Encoding",
-    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.Encoding",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.Encoding",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Security.Cryptography.Encoding",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Security.Cryptography.Encoding",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Security.Cryptography.Encoding",
+    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.Encoding",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.Encoding",
     visibility = ["//visibility:public"],
 )
 
@@ -2916,11 +2916,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Security.Cryptography.Primitives",
     net472 = "@net472//:System.Security.Cryptography.Primitives",
     net48 = "@net48//:System.Security.Cryptography.Primitives",
-    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.Primitives",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.Primitives",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Security.Cryptography.Primitives",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Security.Cryptography.Primitives",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Security.Cryptography.Primitives",
+    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.Primitives",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.Primitives",
     visibility = ["//visibility:public"],
 )
 
@@ -2929,11 +2929,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Security.Cryptography.X509Certificates",
     net472 = "@net472//:System.Security.Cryptography.X509Certificates",
     net48 = "@net48//:System.Security.Cryptography.X509Certificates",
-    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.X509Certificates",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.X509Certificates",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Security.Cryptography.X509Certificates",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Security.Cryptography.X509Certificates",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Security.Cryptography.X509Certificates",
+    netstandard2_0 = "@NetStandard.Library//:System.Security.Cryptography.X509Certificates",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Cryptography.X509Certificates",
     visibility = ["//visibility:public"],
 )
 
@@ -2949,11 +2949,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Security.Principal",
     net472 = "@net472//:System.Security.Principal",
     net48 = "@net48//:System.Security.Principal",
-    netstandard2_0 = "@NetStandard.Library//:System.Security.Principal",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Principal",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Security.Principal",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Security.Principal",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Security.Principal",
+    netstandard2_0 = "@NetStandard.Library//:System.Security.Principal",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.Principal",
     visibility = ["//visibility:public"],
 )
 
@@ -2962,11 +2962,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Security.SecureString",
     net472 = "@net472//:System.Security.SecureString",
     net48 = "@net48//:System.Security.SecureString",
-    netstandard2_0 = "@NetStandard.Library//:System.Security.SecureString",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.SecureString",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Security.SecureString",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Security.SecureString",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Security.SecureString",
+    netstandard2_0 = "@NetStandard.Library//:System.Security.SecureString",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Security.SecureString",
     visibility = ["//visibility:public"],
 )
 
@@ -3154,11 +3154,11 @@ import_multiframework_library(
     net471 = "@net471//:System.ServiceModel.Web",
     net472 = "@net472//:System.ServiceModel.Web",
     net48 = "@net48//:System.ServiceModel.Web",
-    netstandard2_0 = "@NetStandard.Library//:System.ServiceModel.Web",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.ServiceModel.Web",
     netcoreapp2_1 = "@netcoreapp2.1//:System.ServiceModel.Web",
     netcoreapp2_2 = "@netcoreapp2.2//:System.ServiceModel.Web",
     netcoreapp3_0 = "@netcoreapp3.0//:System.ServiceModel.Web",
+    netstandard2_0 = "@NetStandard.Library//:System.ServiceModel.Web",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.ServiceModel.Web",
     visibility = ["//visibility:public"],
 )
 
@@ -3210,11 +3210,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Text.Encoding",
     net472 = "@net472//:System.Text.Encoding",
     net48 = "@net48//:System.Text.Encoding",
-    netstandard2_0 = "@NetStandard.Library//:System.Text.Encoding",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Text.Encoding",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Text.Encoding",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Text.Encoding",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Text.Encoding",
+    netstandard2_0 = "@NetStandard.Library//:System.Text.Encoding",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Text.Encoding",
     visibility = ["//visibility:public"],
 )
 
@@ -3236,11 +3236,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Text.Encoding.Extensions",
     net472 = "@net472//:System.Text.Encoding.Extensions",
     net48 = "@net48//:System.Text.Encoding.Extensions",
-    netstandard2_0 = "@NetStandard.Library//:System.Text.Encoding.Extensions",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Text.Encoding.Extensions",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Text.Encoding.Extensions",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Text.Encoding.Extensions",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Text.Encoding.Extensions",
+    netstandard2_0 = "@NetStandard.Library//:System.Text.Encoding.Extensions",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Text.Encoding.Extensions",
     visibility = ["//visibility:public"],
 )
 
@@ -3268,11 +3268,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Text.RegularExpressions",
     net472 = "@net472//:System.Text.RegularExpressions",
     net48 = "@net48//:System.Text.RegularExpressions",
-    netstandard2_0 = "@NetStandard.Library//:System.Text.RegularExpressions",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Text.RegularExpressions",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Text.RegularExpressions",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Text.RegularExpressions",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Text.RegularExpressions",
+    netstandard2_0 = "@NetStandard.Library//:System.Text.RegularExpressions",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Text.RegularExpressions",
     visibility = ["//visibility:public"],
 )
 
@@ -3288,11 +3288,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Threading",
     net472 = "@net472//:System.Threading",
     net48 = "@net48//:System.Threading",
-    netstandard2_0 = "@NetStandard.Library//:System.Threading",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Threading",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Threading",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Threading",
+    netstandard2_0 = "@NetStandard.Library//:System.Threading",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading",
     visibility = ["//visibility:public"],
 )
 
@@ -3307,11 +3307,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Threading.Overlapped",
     net472 = "@net472//:System.Threading.Overlapped",
     net48 = "@net48//:System.Threading.Overlapped",
-    netstandard2_0 = "@NetStandard.Library//:System.Threading.Overlapped",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Overlapped",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Threading.Overlapped",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Threading.Overlapped",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Threading.Overlapped",
+    netstandard2_0 = "@NetStandard.Library//:System.Threading.Overlapped",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Overlapped",
     visibility = ["//visibility:public"],
 )
 
@@ -3327,11 +3327,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Threading.Tasks",
     net472 = "@net472//:System.Threading.Tasks",
     net48 = "@net48//:System.Threading.Tasks",
-    netstandard2_0 = "@NetStandard.Library//:System.Threading.Tasks",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Tasks",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Threading.Tasks",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Threading.Tasks",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Threading.Tasks",
+    netstandard2_0 = "@NetStandard.Library//:System.Threading.Tasks",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Tasks",
     visibility = ["//visibility:public"],
 )
 
@@ -3355,11 +3355,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Threading.Tasks",
     net472 = "@net472//:System.Threading.Tasks",
     net48 = "@net48//:System.Threading.Tasks",
-    netstandard2_0 = "@NetStandard.Library//:System.Threading.Tasks.Extensions",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Tasks.Extensions",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Threading.Tasks.Extensions",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Threading.Tasks.Extensions",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Threading.Tasks.Extensions",
+    netstandard2_0 = "@NetStandard.Library//:System.Threading.Tasks.Extensions",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Tasks.Extensions",
     visibility = ["//visibility:public"],
 )
 
@@ -3375,11 +3375,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Threading.Tasks.Parallel",
     net472 = "@net472//:System.Threading.Tasks.Parallel",
     net48 = "@net48//:System.Threading.Tasks.Parallel",
-    netstandard2_0 = "@NetStandard.Library//:System.Threading.Tasks.Parallel",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Tasks.Parallel",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Threading.Tasks.Parallel",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Threading.Tasks.Parallel",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Threading.Tasks.Parallel",
+    netstandard2_0 = "@NetStandard.Library//:System.Threading.Tasks.Parallel",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Tasks.Parallel",
     visibility = ["//visibility:public"],
 )
 
@@ -3388,11 +3388,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Threading.Thread",
     net472 = "@net472//:System.Threading.Thread",
     net48 = "@net48//:System.Threading.Thread",
-    netstandard2_0 = "@NetStandard.Library//:System.Threading.Thread",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Thread",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Threading.Thread",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Threading.Thread",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Threading.Thread",
+    netstandard2_0 = "@NetStandard.Library//:System.Threading.Thread",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Thread",
     visibility = ["//visibility:public"],
 )
 
@@ -3401,11 +3401,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Threading.ThreadPool",
     net472 = "@net472//:System.Threading.ThreadPool",
     net48 = "@net48//:System.Threading.ThreadPool",
-    netstandard2_0 = "@NetStandard.Library//:System.Threading.ThreadPool",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.ThreadPool",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Threading.ThreadPool",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Threading.ThreadPool",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Threading.ThreadPool",
+    netstandard2_0 = "@NetStandard.Library//:System.Threading.ThreadPool",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.ThreadPool",
     visibility = ["//visibility:public"],
 )
 
@@ -3420,11 +3420,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Threading.Timer",
     net472 = "@net472//:System.Threading.Timer",
     net48 = "@net48//:System.Threading.Timer",
-    netstandard2_0 = "@NetStandard.Library//:System.Threading.Timer",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Timer",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Threading.Timer",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Threading.Timer",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Threading.Timer",
+    netstandard2_0 = "@NetStandard.Library//:System.Threading.Timer",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Threading.Timer",
     visibility = ["//visibility:public"],
 )
 
@@ -3442,11 +3442,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Transactions",
     net472 = "@net472//:System.Transactions",
     net48 = "@net48//:System.Transactions",
-    netstandard2_0 = "@NetStandard.Library//:System.Transactions",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Transactions",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Transactions",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Transactions",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Transactions",
+    netstandard2_0 = "@NetStandard.Library//:System.Transactions",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Transactions",
     visibility = ["//visibility:public"],
 )
 
@@ -3463,11 +3463,11 @@ import_multiframework_library(
     net471 = "@net471//:System.ValueTuple",
     net472 = "@net472//:System.ValueTuple",
     net48 = "@net48//:System.ValueTuple",
-    netstandard2_0 = "@NetStandard.Library//:System.ValueTuple",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.ValueTuple",
     netcoreapp2_1 = "@netcoreapp2.1//:System.ValueTuple",
     netcoreapp2_2 = "@netcoreapp2.2//:System.ValueTuple",
     netcoreapp3_0 = "@netcoreapp3.0//:System.ValueTuple",
+    netstandard2_0 = "@NetStandard.Library//:System.ValueTuple",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.ValueTuple",
     visibility = ["//visibility:public"],
 )
 
@@ -3485,11 +3485,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Web",
     net472 = "@net472//:System.Web",
     net48 = "@net48//:System.Web",
-    netstandard2_0 = "@NetStandard.Library//:System.Web",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Web",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Web",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Web",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Web",
+    netstandard2_0 = "@NetStandard.Library//:System.Web",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Web",
     visibility = ["//visibility:public"],
 )
 
@@ -3740,11 +3740,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Windows",
     net472 = "@net472//:System.Windows",
     net48 = "@net48//:System.Windows",
-    netstandard2_0 = "@NetStandard.Library//:System.Windows",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Windows",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Windows",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Windows",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Windows",
+    netstandard2_0 = "@NetStandard.Library//:System.Windows",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Windows",
     visibility = ["//visibility:public"],
 )
 
@@ -3938,11 +3938,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml",
     net472 = "@net472//:System.Xml",
     net48 = "@net48//:System.Xml",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml",
     visibility = ["//visibility:public"],
 )
 
@@ -3959,11 +3959,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml.Linq",
     net472 = "@net472//:System.Xml.Linq",
     net48 = "@net48//:System.Xml.Linq",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml.Linq",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.Linq",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml.Linq",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml.Linq",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml.Linq",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml.Linq",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.Linq",
     visibility = ["//visibility:public"],
 )
 
@@ -3979,11 +3979,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml.ReaderWriter",
     net472 = "@net472//:System.Xml.ReaderWriter",
     net48 = "@net48//:System.Xml.ReaderWriter",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml.ReaderWriter",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.ReaderWriter",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml.ReaderWriter",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml.ReaderWriter",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml.ReaderWriter",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml.ReaderWriter",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.ReaderWriter",
     visibility = ["//visibility:public"],
 )
 
@@ -3999,11 +3999,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml.Serialization",
     net472 = "@net472//:System.Xml.Serialization",
     net48 = "@net48//:System.Xml.Serialization",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml.Serialization",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.Serialization",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml.Serialization",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml.Serialization",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml.Serialization",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml.Serialization",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.Serialization",
     visibility = ["//visibility:public"],
 )
 
@@ -4019,11 +4019,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml.XDocument",
     net472 = "@net472//:System.Xml.XDocument",
     net48 = "@net48//:System.Xml.XDocument",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml.XDocument",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XDocument",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml.XDocument",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml.XDocument",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml.XDocument",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml.XDocument",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XDocument",
     visibility = ["//visibility:public"],
 )
 
@@ -4032,11 +4032,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml.XmlDocument",
     net472 = "@net472//:System.Xml.XmlDocument",
     net48 = "@net48//:System.Xml.XmlDocument",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml.XmlDocument",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XmlDocument",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml.XmlDocument",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml.XmlDocument",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml.XmlDocument",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml.XmlDocument",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XmlDocument",
     visibility = ["//visibility:public"],
 )
 
@@ -4052,11 +4052,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml.XmlSerializer",
     net472 = "@net472//:System.Xml.XmlSerializer",
     net48 = "@net48//:System.Xml.XmlSerializer",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml.XmlSerializer",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XmlSerializer",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml.XmlSerializer",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml.XmlSerializer",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml.XmlSerializer",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml.XmlSerializer",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XmlSerializer",
     visibility = ["//visibility:public"],
 )
 
@@ -4065,11 +4065,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml.XPath",
     net472 = "@net472//:System.Xml.XPath",
     net48 = "@net48//:System.Xml.XPath",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml.XPath",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XPath",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml.XPath",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml.XPath",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml.XPath",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml.XPath",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XPath",
     visibility = ["//visibility:public"],
 )
 
@@ -4078,11 +4078,11 @@ import_multiframework_library(
     net471 = "@net471//:System.Xml.XPath.XDocument",
     net472 = "@net472//:System.Xml.XPath.XDocument",
     net48 = "@net48//:System.Xml.XPath.XDocument",
-    netstandard2_0 = "@NetStandard.Library//:System.Xml.XPath.XDocument",
-    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XPath.XDocument",
     netcoreapp2_1 = "@netcoreapp2.1//:System.Xml.XPath.XDocument",
     netcoreapp2_2 = "@netcoreapp2.2//:System.Xml.XPath.XDocument",
     netcoreapp3_0 = "@netcoreapp3.0//:System.Xml.XPath.XDocument",
+    netstandard2_0 = "@NetStandard.Library//:System.Xml.XPath.XDocument",
+    netstandard2_1 = "@NetStandard.Library.Ref//:System.Xml.XPath.XDocument",
     visibility = ["//visibility:public"],
 )
 

--- a/csharp/private/providers.bzl
+++ b/csharp/private/providers.bzl
@@ -17,7 +17,7 @@ def _make_csharp_provider(tfm):
             "deps": "the non-transitive dependencies for this assembly (used by import_multiframework_library).",
             "transitive_refs": "A list of other assemblies to reference when referencing this assembly in a compilation.",
             "transitive_runfiles": "Runfiles from the transitive dependencies.",
-            "actual_tfm": "The target framework of the actual dlls"
+            "actual_tfm": "The target framework of the actual dlls",
         },
     )
 

--- a/csharp/private/rules/create_net_workspace.bzl
+++ b/csharp/private/rules/create_net_workspace.bzl
@@ -6,12 +6,12 @@ custom workspace rule.
 """
 
 def _create_net_workspace_impl(ctx):
-  # The "trick" here is that repository rules each create a workspace (named by
-  # their name attr). So when we create files with ctx it's inside that
-  # workspace.
+    # The "trick" here is that repository rules each create a workspace (named by
+    # their name attr). So when we create files with ctx it's inside that
+    # workspace.
 
-  ctx.file("WORKSPACE", "workspace(name = \"%s\")\n" % ctx.name)
-  ctx.symlink(ctx.attr.build_file, "BUILD.bazel")
+    ctx.file("WORKSPACE", "workspace(name = \"%s\")\n" % ctx.name)
+    ctx.symlink(ctx.attr.build_file, "BUILD.bazel")
 
 _create_net_workspace = repository_rule(
     _create_net_workspace_impl,
@@ -25,7 +25,6 @@ _create_net_workspace = repository_rule(
 )
 
 def create_net_workspace():
-  """Create the @net workspace."""
+    """Create the @net workspace."""
 
-  _create_net_workspace(name = "net")
-
+    _create_net_workspace(name = "net")

--- a/csharp/private/rules/imports.bzl
+++ b/csharp/private/rules/imports.bzl
@@ -35,7 +35,7 @@ def _import_library(ctx):
             deps = ctx.attr.deps,
             transitive_refs = refs,
             transitive_runfiles = runfiles,
-            actual_tfm = tfm
+            actual_tfm = tfm,
         ),
     }
 

--- a/csharp/private/rules/library_set.bzl
+++ b/csharp/private/rules/library_set.bzl
@@ -21,7 +21,7 @@ def _library_set(ctx):
             deps = ctx.attr.deps,
             transitive_refs = refs,
             transitive_runfiles = runfiles,
-            actual_tfm = tfm
+            actual_tfm = tfm,
         ),
     }
 

--- a/csharp/private/rules/wrapper.bzl
+++ b/csharp/private/rules/wrapper.bzl
@@ -27,7 +27,7 @@ dotnet_wrapper = rule(
             doc = """Path to the program that will wrap the dotnet executable.
 This program will be compiled and used instead of directly calling the dotnet executable.""",
             default = Label(_TEMPLATE),
-            allow_single_file = True
+            allow_single_file = True,
         ),
         "src": attr.label_list(
             doc = """The name of the dotnet executable.

--- a/csharp/private/sdk.bzl
+++ b/csharp/private/sdk.bzl
@@ -3,7 +3,7 @@
 #
 # You can get the latest URLs from here:
 #   https://dotnet.microsoft.com/download/dotnet-core
-DOTNET_SDK_VERSION="3.1.100"
+DOTNET_SDK_VERSION = "3.1.100"
 DOTNET_SDK = {
     "windows": {
         "url": "https://download.visualstudio.microsoft.com/download/pr/28a2c4ff-6154-473b-bd51-c62c76171551/ea47eab2219f323596c039b3b679c3d6/dotnet-sdk-3.1.100-win-x64.zip",

--- a/csharp/private/toolchains.bzl
+++ b/csharp/private/toolchains.bzl
@@ -40,7 +40,6 @@ def configure_toolchain(os, exe = "dotnetw"):
             "@platforms//os:" + os,
             "@platforms//cpu:x86_64",
         ],
-
         toolchain = "csharp_x86_64-" + os,
         toolchain_type = ":toolchain_type",
     )

--- a/examples/diamond/BUILD
+++ b/examples/diamond/BUILD
@@ -8,29 +8,32 @@ load("@d2l_rules_csharp//csharp:defs.bzl", "csharp_library")
 csharp_library(
     name = "Top",
     srcs = ["Top.cs"],
-    target_frameworks= ["net48"],
-    deps = ["Left", "Right"],
+    target_frameworks = ["net48"],
+    deps = [
+        "Left",
+        "Right",
+    ],
 )
 
 csharp_library(
     name = "Left",
     srcs = ["Left.cs"],
-    target_frameworks= ["net45"],
+    target_frameworks = ["net45"],
     deps = ["Bottom"],
 )
 
 csharp_library(
     name = "Right",
     srcs = ["Right.cs"],
-    target_frameworks= ["netstandard2.0"],
+    target_frameworks = ["netstandard2.0"],
     deps = ["Bottom"],
 )
 
 csharp_library(
     name = "Bottom",
     srcs = ["Bottom.cs"],
-    include_stdrefs = False, # TODO: remove this when we support netstandard1.4's stdlib
-    target_frameworks= [
+    include_stdrefs = False,  # TODO: remove this when we support netstandard1.4's stdlib
+    target_frameworks = [
         "net48",
         "net40",
         "netstandard1.4",

--- a/examples/every_framework_empty/BUILD
+++ b/examples/every_framework_empty/BUILD
@@ -4,86 +4,86 @@ load(
 )
 
 csharp_library(
-	name = "net20",
-	target_frameworks = ["net20"],
+    name = "net20",
+    target_frameworks = ["net20"],
 )
 
 csharp_library(
-	name = "net40",
-	target_frameworks = ["net40"],
+    name = "net40",
+    target_frameworks = ["net40"],
 )
 
 csharp_library(
-	name = "net45",
-	target_frameworks = ["net45"],
+    name = "net45",
+    target_frameworks = ["net45"],
 )
 
 csharp_library(
-	name = "net451",
-	target_frameworks = ["net451"],
+    name = "net451",
+    target_frameworks = ["net451"],
 )
 
 csharp_library(
-	name = "net452",
-	target_frameworks = ["net452"],
+    name = "net452",
+    target_frameworks = ["net452"],
 )
 
 csharp_library(
-	name = "net46",
-	target_frameworks = ["net46"],
+    name = "net46",
+    target_frameworks = ["net46"],
 )
 
 csharp_library(
-	name = "net461",
-	target_frameworks = ["net461"],
+    name = "net461",
+    target_frameworks = ["net461"],
 )
 
 csharp_library(
-	name = "net462",
-	target_frameworks = ["net462"],
+    name = "net462",
+    target_frameworks = ["net462"],
 )
 
 csharp_library(
-	name = "net47",
-	target_frameworks = ["net47"],
+    name = "net47",
+    target_frameworks = ["net47"],
 )
 
 csharp_library(
-	name = "net471",
-	target_frameworks = ["net471"],
+    name = "net471",
+    target_frameworks = ["net471"],
 )
 
 csharp_library(
-	name = "net472",
-	target_frameworks = ["net472"],
+    name = "net472",
+    target_frameworks = ["net472"],
 )
 
 csharp_library(
-	name = "net48",
-	target_frameworks = ["net48"],
+    name = "net48",
+    target_frameworks = ["net48"],
 )
 
 csharp_library(
-	name = "netcoreapp2.1",
-	target_frameworks = ["netcoreapp2.1"],
+    name = "netcoreapp2.1",
+    target_frameworks = ["netcoreapp2.1"],
 )
 
 csharp_library(
-	name = "netcoreapp2.2",
-	target_frameworks = ["netcoreapp2.2"],
+    name = "netcoreapp2.2",
+    target_frameworks = ["netcoreapp2.2"],
 )
 
 csharp_library(
-	name = "netcoreapp3.0",
-	target_frameworks = ["netcoreapp3.0"],
+    name = "netcoreapp3.0",
+    target_frameworks = ["netcoreapp3.0"],
 )
 
 csharp_library(
-	name = "netstandard2.0",
-	target_frameworks = ["netstandard2.0"],
+    name = "netstandard2.0",
+    target_frameworks = ["netstandard2.0"],
 )
 
 csharp_library(
-	name = "netstandard2.1",
-	target_frameworks = ["netstandard2.1"],
+    name = "netstandard2.1",
+    target_frameworks = ["netstandard2.1"],
 )

--- a/examples/import_nuget_package/BUILD
+++ b/examples/import_nuget_package/BUILD
@@ -13,7 +13,7 @@ csharp_library(
 csharp_library(
     name = "OldThing",
     srcs = ["Class.cs"],
-    target_frameworks = ["net11"],
     include_stdrefs = False,
+    target_frameworks = ["net11"],
     deps = ["@ExamplePackageFolder//:SomePackage"],
 )


### PR DESCRIPTION
While raising some of my recent pull requests, I have been noticing that there are some files that I keep re-formatting. I'd prefer to get all of these sorted, rather than format the files one-by-one.

This PR runs `buildifier -r .` on the entire codebase, ensuring that everything is following the standard set by `buildifier`.

We should look at potentially enforcing these format standards in some way with a pre-commit hook, or some supportive tooling.

