### PR TITLE
Aggregate the bazel rules files for use in tooling

### DIFF
--- a/csharp/BUILD
+++ b/csharp/BUILD
@@ -1,0 +1,6 @@
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["*.bzl"]) + [
+        "//csharp/private:bzl_srcs",
+    ],
+)

--- a/csharp/defs.bzl
+++ b/csharp/defs.bzl
@@ -4,37 +4,37 @@ load(
     _csharp_repositories = "csharp_repositories",
 )
 load(
-    "//csharp/private:rules/binary.bzl",
+    "//csharp/private/rules:binary.bzl",
     _csharp_binary = "csharp_binary",
 )
 load(
-    "//csharp/private:rules/wrapper.bzl",
+    "//csharp/private/rules:wrapper.bzl",
     _dotnet_wrapper = "dotnet_wrapper",
 )
 load(
-    "//csharp/private:rules/library.bzl",
+    "//csharp/private/rules:library.bzl",
     _csharp_library = "csharp_library",
 )
 load(
-    "//csharp/private:rules/library_set.bzl",
+    "//csharp/private/rules:library_set.bzl",
     _csharp_library_set = "csharp_library_set",
 )
 load(
-    "//csharp/private:rules/nunit_test.bzl",
+    "//csharp/private/rules:nunit_test.bzl",
     _csharp_nunit_test = "csharp_nunit_test",
 )
 load(
-    "//csharp/private:rules/imports.bzl",
+    "//csharp/private/rules:imports.bzl",
     _import_library = "import_library",
     _import_multiframework_library = "import_multiframework_library",
 )
 load(
-    "//csharp/private:macros/nuget.bzl",
+    "//csharp/private/macros:nuget.bzl",
     _import_nuget_package = "import_nuget_package",
     _nuget_package = "nuget_package",
 )
 load(
-    "//csharp/private:macros/setup_basic_nuget_package.bzl",
+    "//csharp/private/macros:setup_basic_nuget_package.bzl",
     _setup_basic_nuget_package = "setup_basic_nuget_package",
 )
 

--- a/csharp/private/BUILD
+++ b/csharp/private/BUILD
@@ -1,5 +1,15 @@
 load(":toolchains.bzl", "configure_toolchain")
 
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["*.bzl"]) + [
+        "//csharp/private/actions:bzl_srcs",
+        "//csharp/private/macros:bzl_srcs",
+        "//csharp/private/rules:bzl_srcs",
+    ],
+    visibility = ["//csharp:__pkg__"],
+)
+
 exports_files([
     "nunit/shim.cs",
     "wrappers/dotnet.cc",

--- a/csharp/private/actions/BUILD
+++ b/csharp/private/actions/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//csharp/private:__pkg__"],
+)

--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -1,11 +1,11 @@
 load(
-    "@d2l_rules_csharp//csharp/private:common.bzl",
+    "//csharp/private:common.bzl",
     "collect_transitive_info",
     "get_analyzer_dll",
     "use_highentropyva",
 )
 load(
-    "@d2l_rules_csharp//csharp/private:providers.bzl",
+    "//csharp/private:providers.bzl",
     "CSharpAssembly",
     "DefaultLangVersion",
     "SubsystemVersion",

--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -1,5 +1,5 @@
 load(
-    "@d2l_rules_csharp//csharp/private:providers.bzl",
+    "//csharp/private:providers.bzl",
     "CSharpAssembly",
     "FrameworkCompatibility",
 )

--- a/csharp/private/macros/BUILD
+++ b/csharp/private/macros/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//csharp/private:__pkg__"],
+)

--- a/csharp/private/macros/setup_basic_nuget_package.bzl
+++ b/csharp/private/macros/setup_basic_nuget_package.bzl
@@ -1,5 +1,5 @@
 load("//csharp/private:providers.bzl", "CSharpAssembly")
-load("//csharp/private:rules/imports.bzl", "import_library", "import_multiframework_library")
+load("//csharp/private/rules:imports.bzl", "import_library", "import_multiframework_library")
 
 def _import_dll(dll, has_pdb, imports):
     path = dll.split("/")

--- a/csharp/private/net/BUILD
+++ b/csharp/private/net/BUILD
@@ -1,4 +1,4 @@
-load("@d2l_rules_csharp//csharp/private:rules/imports.bzl", "import_multiframework_library")
+load("@d2l_rules_csharp//csharp/private/rules:imports.bzl", "import_multiframework_library")
 
 import_multiframework_library(
     name = "StandardReferences",

--- a/csharp/private/repositories.bzl
+++ b/csharp/private/repositories.bzl
@@ -1,6 +1,6 @@
 load(":sdk.bzl", "DOTNET_SDK")
-load(":rules/create_net_workspace.bzl", "create_net_workspace")
-load(":macros/nuget.bzl", "nuget_package")
+load("//csharp/private/rules:create_net_workspace.bzl", "create_net_workspace")
+load("//csharp/private/macros:nuget.bzl", "nuget_package")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def csharp_repositories():

--- a/csharp/private/rules/BUILD
+++ b/csharp/private/rules/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//csharp/private:__pkg__"],
+)

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -1,7 +1,7 @@
-load("@d2l_rules_csharp//csharp/private:providers.bzl", "AnyTargetFramework")
-load("@d2l_rules_csharp//csharp/private:actions/assembly.bzl", "AssemblyAction")
+load("//csharp/private:providers.bzl", "AnyTargetFramework")
+load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(
-    "@d2l_rules_csharp//csharp/private:common.bzl",
+    "//csharp/private:common.bzl",
     "fill_in_missing_frameworks",
     "is_debug",
     "is_standard_framework",

--- a/csharp/private/rules/imports.bzl
+++ b/csharp/private/rules/imports.bzl
@@ -1,9 +1,9 @@
 load(
-    "@d2l_rules_csharp//csharp/private:common.bzl",
+    "//csharp/private:common.bzl",
     "collect_transitive_info",
     "fill_in_missing_frameworks",
 )
-load("@d2l_rules_csharp//csharp/private:providers.bzl", "AnyTargetFramework", "CSharpAssembly")
+load("//csharp/private:providers.bzl", "AnyTargetFramework", "CSharpAssembly")
 
 def _import_library(ctx):
     files = []

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -1,7 +1,7 @@
-load("@d2l_rules_csharp//csharp/private:providers.bzl", "AnyTargetFramework")
-load("@d2l_rules_csharp//csharp/private:actions/assembly.bzl", "AssemblyAction")
+load("//csharp/private:providers.bzl", "AnyTargetFramework")
+load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(
-    "@d2l_rules_csharp//csharp/private:common.bzl",
+    "//csharp/private:common.bzl",
     "fill_in_missing_frameworks",
     "is_debug",
 )

--- a/csharp/private/rules/library_set.bzl
+++ b/csharp/private/rules/library_set.bzl
@@ -1,9 +1,9 @@
 load(
-    "@d2l_rules_csharp//csharp/private:common.bzl",
+    "//csharp/private:common.bzl",
     "collect_transitive_info",
     "fill_in_missing_frameworks",
 )
-load("@d2l_rules_csharp//csharp/private:providers.bzl", "AnyTargetFramework", "CSharpAssembly")
+load("//csharp/private:providers.bzl", "AnyTargetFramework", "CSharpAssembly")
 
 def _library_set(ctx):
     files = []

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -1,7 +1,7 @@
-load("@d2l_rules_csharp//csharp/private:providers.bzl", "AnyTargetFramework")
-load("@d2l_rules_csharp//csharp/private:actions/assembly.bzl", "AssemblyAction")
+load("//csharp/private:providers.bzl", "AnyTargetFramework")
+load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(
-    "@d2l_rules_csharp//csharp/private:common.bzl",
+    "//csharp/private:common.bzl",
     "fill_in_missing_frameworks",
     "is_debug",
     "is_standard_framework",

--- a/csharp/private/rules/wrapper.bzl
+++ b/csharp/private/rules/wrapper.bzl
@@ -1,4 +1,4 @@
-_TEMPLATE = "@d2l_rules_csharp//csharp/private:wrappers/dotnet.cc"
+_TEMPLATE = "//csharp/private:wrappers/dotnet.cc"
 
 def _dotnet_wrapper_impl(ctx):
     cc_file = ctx.actions.declare_file("%s.cc" % (ctx.attr.name))


### PR DESCRIPTION
Aggregate all of the bazel sources together as using the model of `bzl_srcs`. This allows us to configure docs or tools on the bazel rule themselves. The top level is not accessible to any packages (e.g. `//docs`), as that will be handled in #110.

This PR aggregates all of the bazel sources to the top level using filegroups and the `bzl_srcs` model. This allows us to run tooling against our bazel rules files.

Relates to #17 