### PR TITLE
Run buildifier in CI to keep formatting

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,6 +3,7 @@ bazel: 1.2.1
 
 buildifier:
   version: latest
+  warnings: disable=module-docstring,disable=function-docstring,disable=function-docstring-args
 
 tasks:
   examples-windows:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,30 +1,34 @@
 ---
 bazel: 1.2.1
+
+buildifier:
+  version: latest
+
 tasks:
   examples-windows:
     name: Examples on Windows
     platform: windows
     include_json_profile:
-    - build
-    - test
+      - build
+      - test
     working_directory: examples
     build_targets:
-    - ...
+      - ...
   examples-ubuntu1804:
     name: Examples on Ubuntu 18.04
     platform: ubuntu1804
     include_json_profile:
-    - build
-    - test
+      - build
+      - test
     working_directory: examples
     build_targets:
-    - ...
+      - ...
   examples-macos:
     name: Examples on macOS
     platform: macos
     include_json_profile:
-    - build
-    - test
+      - build
+      - test
     working_directory: examples
     build_targets:
-    - ...
+      - ...

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,7 +3,6 @@ bazel: 1.2.1
 
 buildifier:
   version: latest
-  warnings: disable=module-docstring,disable=function-docstring,disable=function-docstring-args
 
 tasks:
   examples-windows:

--- a/csharp/defs.bzl
+++ b/csharp/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "//csharp/private:repositories.bzl",
     _csharp_register_toolchains = "csharp_register_toolchains",

--- a/csharp/private/BUILD
+++ b/csharp/private/BUILD
@@ -1,3 +1,4 @@
+# buildifier: disable=positional-args
 load(":toolchains.bzl", "configure_toolchain")
 
 filegroup(

--- a/csharp/private/BUILD
+++ b/csharp/private/BUILD
@@ -1,4 +1,3 @@
-# buildifier: disable=positional-args
 load(":toolchains.bzl", "configure_toolchain")
 
 filegroup(
@@ -18,8 +17,8 @@ exports_files([
 
 toolchain_type(name = "toolchain_type")
 
-configure_toolchain("windows")
+configure_toolchain("windows")  # buildifier: disable=positional-args
 
-configure_toolchain("linux")
+configure_toolchain("linux")  # buildifier: disable=positional-args
 
-configure_toolchain("osx")
+configure_toolchain("osx")  # buildifier: disable=positional-args

--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -1,5 +1,4 @@
 # buildifier: disable=module-docstring
-# buildifier: disable=function-docstring
 load(
     "//csharp/private:common.bzl",
     "collect_transitive_info",
@@ -45,6 +44,7 @@ def _framework_preprocessor_symbols(tfm):
         return ["NETFRAMEWORK", specific]
 
 def AssemblyAction(
+        # buildifier: disable=function-docstring
         actions,
         name,
         additionalfiles,

--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -1,3 +1,5 @@
+# buildifier: disable=module-docstring
+# buildifier: disable=function-docstring
 load(
     "//csharp/private:common.bzl",
     "collect_transitive_info",

--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -43,8 +43,8 @@ def _framework_preprocessor_symbols(tfm):
     else:
         return ["NETFRAMEWORK", specific]
 
+# buildifier: disable=function-docstring
 def AssemblyAction(
-        # buildifier: disable=function-docstring
         actions,
         name,
         additionalfiles,

--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -1,3 +1,6 @@
+# buildifier: disable=module-docstring
+# buildifier: disable=function-docstring
+# buildifier: disable=function-docstring-args
 load(
     "//csharp/private:providers.bzl",
     "CSharpAssembly",

--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -1,6 +1,4 @@
 # buildifier: disable=module-docstring
-# buildifier: disable=function-docstring
-# buildifier: disable=function-docstring-args
 load(
     "//csharp/private:providers.bzl",
     "CSharpAssembly",
@@ -19,6 +17,7 @@ def use_highentropyva(tfm):
 def is_standard_framework(tfm):
     return tfm.startswith("netstandard")
 
+# buildifier: disable=function-docstring
 def collect_transitive_info(deps, tfm):
     direct_refs = []
     transitive_refs = []
@@ -72,7 +71,6 @@ def fill_in_missing_frameworks(providers):
 
     Args:
       providers: a dict from TFM to a provider.
-      deps: the original deps used to generate the providers.
     """
 
     # iterate through the compatability table since it's in preference order

--- a/csharp/private/macros/nuget.bzl
+++ b/csharp/private/macros/nuget.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=function-docstring-args
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _get_build_file_content(build_file, build_file_content):

--- a/csharp/private/macros/nuget.bzl
+++ b/csharp/private/macros/nuget.bzl
@@ -1,4 +1,3 @@
-# buildifier: disable=function-docstring-args
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _get_build_file_content(build_file, build_file_content):
@@ -11,6 +10,7 @@ setup_basic_nuget_package()
     return build_file_content
 
 def import_nuget_package(
+        # buildifier: disable=function-docstring-args
         name,
         dir = None,
         file = None,

--- a/csharp/private/macros/nuget.bzl
+++ b/csharp/private/macros/nuget.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _get_build_file_content(build_file, build_file_content):
@@ -10,7 +11,6 @@ setup_basic_nuget_package()
     return build_file_content
 
 def import_nuget_package(
-        # buildifier: disable=function-docstring-args
         name,
         dir = None,
         file = None,
@@ -86,6 +86,7 @@ def nuget_package(
     Args:
       name: A unique name for the package's workspace.
       package: The name of the package in the NuGet feed.
+      version: The version of the package in the NuGet feed.
       nuget_sources: A list of nuget package sources. Defaults to nuget.org.
       sha256: The SHA256 of the package.
       build_file: The path to a BUILD file to use for the package.

--- a/csharp/private/macros/setup_basic_nuget_package.bzl
+++ b/csharp/private/macros/setup_basic_nuget_package.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("//csharp/private:providers.bzl", "CSharpAssembly")
 load("//csharp/private/rules:imports.bzl", "import_library", "import_multiframework_library")
 

--- a/csharp/private/net/BUILD
+++ b/csharp/private/net/BUILD
@@ -1,3 +1,4 @@
+# buildifier: disable=bzl-visibility
 load("@d2l_rules_csharp//csharp/private/rules:imports.bzl", "import_multiframework_library")
 
 import_multiframework_library(

--- a/csharp/private/providers.bzl
+++ b/csharp/private/providers.bzl
@@ -1,4 +1,3 @@
-# buildifier: disable=name-conventions
 """Define the CSharpAssembly_-prefixed providers
 
 This module defines one provider per target framework and creates some handy
@@ -24,41 +23,42 @@ def _make_csharp_provider(tfm):
 
 # Bazel requires that providers be "top level" objects, so this stuff is a bit
 # more boilerplate than it could otherwise be.
-CSharpAssembly_netstandard = _make_csharp_provider("netstandard")
-CSharpAssembly_netstandard10 = _make_csharp_provider("netstandard1.0")
-CSharpAssembly_netstandard11 = _make_csharp_provider("netstandard1.1")
-CSharpAssembly_netstandard12 = _make_csharp_provider("netstandard1.2")
-CSharpAssembly_netstandard13 = _make_csharp_provider("netstandard1.3")
-CSharpAssembly_netstandard14 = _make_csharp_provider("netstandard1.4")
-CSharpAssembly_netstandard15 = _make_csharp_provider("netstandard1.5")
-CSharpAssembly_netstandard16 = _make_csharp_provider("netstandard1.6")
-CSharpAssembly_netstandard20 = _make_csharp_provider("netstandard2.0")
-CSharpAssembly_netstandard21 = _make_csharp_provider("netstandard2.1")
-CSharpAssembly_net11 = _make_csharp_provider("net11")
-CSharpAssembly_net20 = _make_csharp_provider("net20")
-CSharpAssembly_net30 = _make_csharp_provider("net30")
-CSharpAssembly_net35 = _make_csharp_provider("net35")
-CSharpAssembly_net40 = _make_csharp_provider("net40")
-CSharpAssembly_net403 = _make_csharp_provider("net403")
-CSharpAssembly_net45 = _make_csharp_provider("net45")
-CSharpAssembly_net451 = _make_csharp_provider("net451")
-CSharpAssembly_net452 = _make_csharp_provider("net452")
-CSharpAssembly_net46 = _make_csharp_provider("net46")
-CSharpAssembly_net461 = _make_csharp_provider("net461")
-CSharpAssembly_net462 = _make_csharp_provider("net462")
-CSharpAssembly_net47 = _make_csharp_provider("net47")
-CSharpAssembly_net471 = _make_csharp_provider("net471")
-CSharpAssembly_net472 = _make_csharp_provider("net472")
-CSharpAssembly_net48 = _make_csharp_provider("net48")
-CSharpAssembly_netcoreapp10 = _make_csharp_provider("netcoreapp1.0")
-CSharpAssembly_netcoreapp11 = _make_csharp_provider("netcoreapp1.1")
-CSharpAssembly_netcoreapp20 = _make_csharp_provider("netcoreapp2.0")
-CSharpAssembly_netcoreapp21 = _make_csharp_provider("netcoreapp2.1")
-CSharpAssembly_netcoreapp22 = _make_csharp_provider("netcoreapp2.2")
-CSharpAssembly_netcoreapp30 = _make_csharp_provider("netcoreapp3.0")
+CSharpAssembly_netstandard = _make_csharp_provider("netstandard")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard10 = _make_csharp_provider("netstandard1.0")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard11 = _make_csharp_provider("netstandard1.1")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard12 = _make_csharp_provider("netstandard1.2")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard13 = _make_csharp_provider("netstandard1.3")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard14 = _make_csharp_provider("netstandard1.4")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard15 = _make_csharp_provider("netstandard1.5")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard16 = _make_csharp_provider("netstandard1.6")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard20 = _make_csharp_provider("netstandard2.0")  # buildifier: disable=name-conventions
+CSharpAssembly_netstandard21 = _make_csharp_provider("netstandard2.1")  # buildifier: disable=name-conventions
+CSharpAssembly_net11 = _make_csharp_provider("net11")  # buildifier: disable=name-conventions
+CSharpAssembly_net20 = _make_csharp_provider("net20")  # buildifier: disable=name-conventions
+CSharpAssembly_net30 = _make_csharp_provider("net30")  # buildifier: disable=name-conventions
+CSharpAssembly_net35 = _make_csharp_provider("net35")  # buildifier: disable=name-conventions
+CSharpAssembly_net40 = _make_csharp_provider("net40")  # buildifier: disable=name-conventions
+CSharpAssembly_net403 = _make_csharp_provider("net403")  # buildifier: disable=name-conventions
+CSharpAssembly_net45 = _make_csharp_provider("net45")  # buildifier: disable=name-conventions
+CSharpAssembly_net451 = _make_csharp_provider("net451")  # buildifier: disable=name-conventions
+CSharpAssembly_net452 = _make_csharp_provider("net452")  # buildifier: disable=name-conventions
+CSharpAssembly_net46 = _make_csharp_provider("net46")  # buildifier: disable=name-conventions
+CSharpAssembly_net461 = _make_csharp_provider("net461")  # buildifier: disable=name-conventions
+CSharpAssembly_net462 = _make_csharp_provider("net462")  # buildifier: disable=name-conventions
+CSharpAssembly_net47 = _make_csharp_provider("net47")  # buildifier: disable=name-conventions
+CSharpAssembly_net471 = _make_csharp_provider("net471")  # buildifier: disable=name-conventions
+CSharpAssembly_net472 = _make_csharp_provider("net472")  # buildifier: disable=name-conventions
+CSharpAssembly_net48 = _make_csharp_provider("net48")  # buildifier: disable=name-conventions
+CSharpAssembly_netcoreapp10 = _make_csharp_provider("netcoreapp1.0")  # buildifier: disable=name-conventions
+CSharpAssembly_netcoreapp11 = _make_csharp_provider("netcoreapp1.1")  # buildifier: disable=name-conventions
+CSharpAssembly_netcoreapp20 = _make_csharp_provider("netcoreapp2.0")  # buildifier: disable=name-conventions
+CSharpAssembly_netcoreapp21 = _make_csharp_provider("netcoreapp2.1")  # buildifier: disable=name-conventions
+CSharpAssembly_netcoreapp22 = _make_csharp_provider("netcoreapp2.2")  # buildifier: disable=name-conventions
+CSharpAssembly_netcoreapp30 = _make_csharp_provider("netcoreapp3.0")  # buildifier: disable=name-conventions
 
 # A dict from TFM to provider. The order of keys is not used.
 CSharpAssembly = {
+    # buildifier: disable=name-conventions
     "netstandard": CSharpAssembly_netstandard,
     "netstandard1.0": CSharpAssembly_netstandard10,
     "netstandard1.1": CSharpAssembly_netstandard11,
@@ -98,6 +98,7 @@ CSharpAssembly = {
 # matters. netstandard should appear first, and keys within a family should
 # proceed from oldest to newest
 FrameworkCompatibility = {
+    # buildifier: disable=name-conventions
     # .NET Standard
     "netstandard": [],
     "netstandard1.0": ["netstandard"],
@@ -138,6 +139,7 @@ FrameworkCompatibility = {
 }
 
 SubsystemVersion = {
+    # buildifier: disable=name-conventions
     "netstandard": None,
     "netstandard1.0": None,
     "netstandard1.1": None,
@@ -173,6 +175,7 @@ SubsystemVersion = {
 }
 
 DefaultLangVersion = {
+    # buildifier: disable=name-conventions
     "netstandard": "7.3",
     "netstandard1.0": "7.3",
     "netstandard1.1": "7.3",
@@ -209,4 +212,4 @@ DefaultLangVersion = {
 
 # A convenience used in attributes that need to specify that they accept any
 # kind of C# assembly. This is an array of single-element arrays.
-AnyTargetFramework = [[a] for a in CSharpAssembly.values()]
+AnyTargetFramework = [[a] for a in CSharpAssembly.values()]  # buildifier: disable=name-conventions

--- a/csharp/private/providers.bzl
+++ b/csharp/private/providers.bzl
@@ -57,8 +57,8 @@ CSharpAssembly_netcoreapp22 = _make_csharp_provider("netcoreapp2.2")  # buildifi
 CSharpAssembly_netcoreapp30 = _make_csharp_provider("netcoreapp3.0")  # buildifier: disable=name-conventions
 
 # A dict from TFM to provider. The order of keys is not used.
-CSharpAssembly = {
-    # buildifier: disable=name-conventions
+# buildifier: disable=name-conventions
+CSharpAssembly = {    
     "netstandard": CSharpAssembly_netstandard,
     "netstandard1.0": CSharpAssembly_netstandard10,
     "netstandard1.1": CSharpAssembly_netstandard11,
@@ -97,8 +97,8 @@ CSharpAssembly = {
 # against. This relationship is transitive. The order of this dictionary also
 # matters. netstandard should appear first, and keys within a family should
 # proceed from oldest to newest
+# buildifier: disable=name-conventions
 FrameworkCompatibility = {
-    # buildifier: disable=name-conventions
     # .NET Standard
     "netstandard": [],
     "netstandard1.0": ["netstandard"],
@@ -138,8 +138,8 @@ FrameworkCompatibility = {
     "netcoreapp3.0": ["netcoreapp2.2", "netstandard2.1"],
 }
 
+# buildifier: disable=name-conventions
 SubsystemVersion = {
-    # buildifier: disable=name-conventions
     "netstandard": None,
     "netstandard1.0": None,
     "netstandard1.1": None,
@@ -174,8 +174,8 @@ SubsystemVersion = {
     "netcoreapp3.0": None,
 }
 
+# buildifier: disable=name-conventions
 DefaultLangVersion = {
-    # buildifier: disable=name-conventions
     "netstandard": "7.3",
     "netstandard1.0": "7.3",
     "netstandard1.1": "7.3",

--- a/csharp/private/providers.bzl
+++ b/csharp/private/providers.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=name-conventions
 """Define the CSharpAssembly_-prefixed providers
 
 This module defines one provider per target framework and creates some handy

--- a/csharp/private/repositories.bzl
+++ b/csharp/private/repositories.bzl
@@ -1,3 +1,5 @@
+# buildifier: disable=module-docstring
+# buildifier: disable=function-docstring
 load(":sdk.bzl", "DOTNET_SDK")
 load("//csharp/private/rules:create_net_workspace.bzl", "create_net_workspace")
 load("//csharp/private/macros:nuget.bzl", "nuget_package")

--- a/csharp/private/repositories.bzl
+++ b/csharp/private/repositories.bzl
@@ -1,11 +1,11 @@
 # buildifier: disable=module-docstring
-# buildifier: disable=function-docstring
 load(":sdk.bzl", "DOTNET_SDK")
 load("//csharp/private/rules:create_net_workspace.bzl", "create_net_workspace")
 load("//csharp/private/macros:nuget.bzl", "nuget_package")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def csharp_repositories():
+    # buildifier: disable=function-docstring
     _net_workspace()
 
     create_net_workspace()

--- a/csharp/private/repositories.bzl
+++ b/csharp/private/repositories.bzl
@@ -4,8 +4,8 @@ load("//csharp/private/rules:create_net_workspace.bzl", "create_net_workspace")
 load("//csharp/private/macros:nuget.bzl", "nuget_package")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# buildifier: disable=function-docstring
 def csharp_repositories():
-    # buildifier: disable=function-docstring
     _net_workspace()
 
     create_net_workspace()

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("//csharp/private:providers.bzl", "AnyTargetFramework")
 load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(

--- a/csharp/private/rules/imports.bzl
+++ b/csharp/private/rules/imports.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "//csharp/private:common.bzl",
     "collect_transitive_info",

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("//csharp/private:providers.bzl", "AnyTargetFramework")
 load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(

--- a/csharp/private/rules/library_set.bzl
+++ b/csharp/private/rules/library_set.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "//csharp/private:common.bzl",
     "collect_transitive_info",

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("//csharp/private:providers.bzl", "AnyTargetFramework")
 load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(

--- a/csharp/private/rules/wrapper.bzl
+++ b/csharp/private/rules/wrapper.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 _TEMPLATE = "//csharp/private:wrappers/dotnet.cc"
 
 def _dotnet_wrapper_impl(ctx):

--- a/csharp/private/sdk.bzl
+++ b/csharp/private/sdk.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 # DotNET SDK Download URLs
 # These are the URLs to download the .NET SDKs for each of the supported operating systems.
 #

--- a/csharp/private/toolchains.bzl
+++ b/csharp/private/toolchains.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(":sdk.bzl", "DOTNET_SDK_VERSION")
 
 def _csharp_toolchain_impl(ctx):


### PR DESCRIPTION
Requires that all WORKSPACE, BUILD, and .bzl files meet lint + formatting rules of buildifier. This is pinned to the latest version.

You can see the documentation for this [here](https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md#running-buildifier-on-ci).

Relates to #101, #111 

Additionally I performed a format of the YAML file, but there isn't any format guideline set in the code like `.clang-format`.