### PR TITLE
buildifier - Resolve 'positional-args' warnings

### DIFF
--- a/csharp/private/BUILD
+++ b/csharp/private/BUILD
@@ -17,8 +17,8 @@ exports_files([
 
 toolchain_type(name = "toolchain_type")
 
-configure_toolchain("windows")  # buildifier: disable=positional-args
+configure_toolchain(os = "windows")
 
-configure_toolchain("linux")  # buildifier: disable=positional-args
+configure_toolchain(os = "linux")
 
-configure_toolchain("osx")  # buildifier: disable=positional-args
+configure_toolchain(os = "osx")


### PR DESCRIPTION
> All top level calls (except for some built-ins) should use keyword args over positional arguments. Positional arguments can cause subtle errors if the order is switched or if an argument is removed. Keyword args also greatly improve readability.

This PR resolves instances of the warning `positional-args` in the repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightspace/rules_csharp/114)
<!-- Reviewable:end -->
