### PR TITLE
Set the module docstrings for all rules

### DIFF
--- a/csharp/defs.bzl
+++ b/csharp/defs.bzl
@@ -1,4 +1,7 @@
-# buildifier: disable=module-docstring
+"""Public API surface is re-exported here.
+
+Users should not load files under "/csharp"
+"""
 load(
     "//csharp/private:repositories.bzl",
     _csharp_register_toolchains = "csharp_register_toolchains",

--- a/csharp/defs.for_docs.bzl
+++ b/csharp/defs.for_docs.bzl
@@ -1,3 +1,7 @@
+"""Public API surface is re-exported here for documentation.
+
+This is used by stardoc to describe the Public API.
+"""
 load(
     "//csharp/private:repositories.bzl",
     _csharp_register_toolchains = "csharp_register_toolchains",

--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Actions for compiling targets with C#.
+"""
 load(
     "//csharp/private:common.bzl",
     "collect_transitive_info",

--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules for compatability resolution of dependencies for .NET frameworks.
+"""
 load(
     "//csharp/private:providers.bzl",
     "CSharpAssembly",

--- a/csharp/private/macros/nuget.bzl
+++ b/csharp/private/macros/nuget.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules for importing NuGet packages.
+"""
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _get_build_file_content(build_file, build_file_content):

--- a/csharp/private/macros/setup_basic_nuget_package.bzl
+++ b/csharp/private/macros/setup_basic_nuget_package.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules for interfacing with NuGet packages. 
+"""
 load("//csharp/private:providers.bzl", "CSharpAssembly")
 load("//csharp/private/rules:imports.bzl", "import_library", "import_multiframework_library")
 

--- a/csharp/private/repositories.bzl
+++ b/csharp/private/repositories.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules to load all the .NET SDK & framework dependencies of rules_csharp.
+"""
 load(":sdk.bzl", "DOTNET_SDK")
 load("//csharp/private/rules:create_net_workspace.bzl", "create_net_workspace")
 load("//csharp/private/macros:nuget.bzl", "nuget_package")

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules for compiling C# binaries.
+"""
 load("//csharp/private:providers.bzl", "AnyTargetFramework")
 load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(

--- a/csharp/private/rules/imports.bzl
+++ b/csharp/private/rules/imports.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules for importing assemblies for .NET frameworks.
+"""
 load(
     "//csharp/private:common.bzl",
     "collect_transitive_info",

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules for compiling C# libraries.
+"""
 load("//csharp/private:providers.bzl", "AnyTargetFramework")
 load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(

--- a/csharp/private/rules/library_set.bzl
+++ b/csharp/private/rules/library_set.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules for aggregating C# libraries for ease of use. 
+"""
 load(
     "//csharp/private:common.bzl",
     "collect_transitive_info",

--- a/csharp/private/rules/nunit_test.bzl
+++ b/csharp/private/rules/nunit_test.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules for compiling NUnit tests.
+"""
 load("//csharp/private:providers.bzl", "AnyTargetFramework")
 load("//csharp/private/actions:assembly.bzl", "AssemblyAction")
 load(

--- a/csharp/private/rules/wrapper.bzl
+++ b/csharp/private/rules/wrapper.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+A wrapper around `dotnet` for Bazel.
+"""
 _TEMPLATE = "//csharp/private:wrappers/dotnet.cc"
 
 def _dotnet_wrapper_impl(ctx):

--- a/csharp/private/sdk.bzl
+++ b/csharp/private/sdk.bzl
@@ -1,9 +1,8 @@
-# buildifier: disable=module-docstring
-# DotNET SDK Download URLs
-# These are the URLs to download the .NET SDKs for each of the supported operating systems.
-#
-# You can get the latest URLs from here:
-#   https://dotnet.microsoft.com/download/dotnet-core
+"""
+Declarations for the .NET SDK Downloads URLs and version
+
+These are the URLs to download the .NET SDKs for each of the supported operating systems. These URLs are accessible from: https://dotnet.microsoft.com/download/dotnet-core.
+"""
 DOTNET_SDK_VERSION = "3.1.100"
 DOTNET_SDK = {
     "windows": {

--- a/csharp/private/toolchains.bzl
+++ b/csharp/private/toolchains.bzl
@@ -1,4 +1,6 @@
-# buildifier: disable=module-docstring
+"""
+Rules to configure the .NET toolchain of rules_csharp.
+"""
 load(":sdk.bzl", "DOTNET_SDK_VERSION")
 
 def _csharp_toolchain_impl(ctx):


### PR DESCRIPTION
Configure docstrings for all of the rules files. The descriptions used for now are simple, but intended to roughly classify what the rule handles.

I expect these will become more verbose as the documentation of the rules are expanded/revised with each issue.