### PR TITLE
Add runtimeconfig.json for .NET Core executables

### DIFF
--- a/csharp/private/BUILD
+++ b/csharp/private/BUILD
@@ -9,6 +9,7 @@ filegroup(
 exports_files([
     "nunit/shim.cs",
     "wrappers/dotnet.cc",
+    "runtimeconfig.json.tpl",
 ])
 
 toolchain_type(name = "toolchain_type")

--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -60,7 +60,8 @@ def AssemblyAction(
         out,
         target,
         target_framework,
-        toolchain):
+        toolchain,
+        runtimeconfig = None):
     out_file_name = name if out == "" else out
     out_dir = "bazelout/" + target_framework
     out_ext = "dll" if target == "library" else "exe"
@@ -193,4 +194,5 @@ def AssemblyAction(
         transitive_refs = refs,
         transitive_runfiles = runfiles,
         actual_tfm = target_framework,
+        runtimeconfig = runtimeconfig,
     )

--- a/csharp/private/actions/write_runtimeconfig.bzl
+++ b/csharp/private/actions/write_runtimeconfig.bzl
@@ -1,0 +1,32 @@
+"""
+Actions for writing *.runtimeconfig.json files.
+"""
+
+load("//csharp/private:sdk.bzl", "RUNTIME_FRAMEWORK_VERSION", "RUNTIME_TFM")
+
+def write_runtimeconfig(actions, template, name, tfm):
+    """Create a *.runtimeconfig.json file.
+    
+    This file is necessary when running a .NET Core binary.
+
+    Args:
+      actions: An actions module, usually from ctx.actions.
+      template: A template file.
+      name: The name of the executable.
+      tfm: The target framework moniker for the exe being built.
+    """
+
+    output = actions.declare_file("bazelout/%s/%s.runtimeconfig.json" % (tfm, name))
+
+    # We're doing this as a template rather than a static file to allow users
+    # to customize this if they wish.
+    actions.expand_template(
+        template = template,
+        output = output,
+        substitutions = {
+            "{RUNTIME_TFM}": RUNTIME_TFM,
+            "{RUNTIME_FRAMEWORK_VERSION}": RUNTIME_FRAMEWORK_VERSION,
+        },
+    )
+
+    return output

--- a/csharp/private/common.bzl
+++ b/csharp/private/common.bzl
@@ -19,6 +19,9 @@ def use_highentropyva(tfm):
 def is_standard_framework(tfm):
     return tfm.startswith("netstandard")
 
+def is_core_framework(tfm):
+    return tfm.startswith("netcoreapp")
+
 # buildifier: disable=function-docstring
 def collect_transitive_info(deps, tfm):
     direct_refs = []

--- a/csharp/private/providers.bzl
+++ b/csharp/private/providers.bzl
@@ -18,6 +18,7 @@ def _make_csharp_provider(tfm):
             "transitive_refs": "A list of other assemblies to reference when referencing this assembly in a compilation.",
             "transitive_runfiles": "Runfiles from the transitive dependencies.",
             "actual_tfm": "The target framework of the actual dlls",
+            "runtimeconfig": "An optional runtimeconfig.json for executable assemblies",
         },
     )
 

--- a/csharp/private/rules/binary.bzl
+++ b/csharp/private/rules/binary.bzl
@@ -8,7 +8,9 @@ load(
     "fill_in_missing_frameworks",
     "is_debug",
     "is_standard_framework",
+    "is_core_framework",
 )
+load("//csharp/private:actions/write_runtimeconfig.bzl", "write_runtimeconfig")
 
 def _binary_impl(ctx):
     providers = {}
@@ -18,6 +20,15 @@ def _binary_impl(ctx):
     for tfm in ctx.attr.target_frameworks:
         if is_standard_framework(tfm):
             fail("It doesn't make sense to build an executable for " + tfm)
+
+        runtimeconfig = None
+        if is_core_framework(tfm):
+            runtimeconfig = write_runtimeconfig(
+                ctx.actions,
+                template = ctx.file.runtimeconfig_template,
+                name = ctx.attr.name,
+                tfm = tfm,
+            )
 
         providers[tfm] = AssemblyAction(
             ctx.actions,
@@ -35,15 +46,22 @@ def _binary_impl(ctx):
             target = "winexe" if ctx.attr.winexe else "exe",
             target_framework = tfm,
             toolchain = ctx.toolchains["@d2l_rules_csharp//csharp/private:toolchain_type"],
+            runtimeconfig = runtimeconfig,
         )
 
     fill_in_missing_frameworks(providers)
 
     result = providers.values()
+
+    direct_runfiles = [result[0].out, result[0].pdb]
+
+    if result[0].runtimeconfig != None:
+        direct_runfiles += [result[0].runtimeconfig]
+
     result.append(DefaultInfo(
         executable = result[0].out,
         runfiles = ctx.runfiles(
-            files = [result[0].out, result[0].pdb],
+            files = direct_runfiles,
             transitive_files = result[0].transitive_runfiles,
         ),
         files = depset([result[0].out, result[0].refout, result[0].pdb]),
@@ -103,6 +121,11 @@ csharp_binary = rule(
         "_stdrefs": attr.label(
             doc = "The standard set of assemblies to reference.",
             default = "@net//:StandardReferences",
+        ),
+        "runtimeconfig_template": attr.label(
+            doc = "A template file to use for generating runtimeconfig.json",
+            default = ":runtimeconfig.json.tpl",
+            allow_single_file = True,
         ),
         "deps": attr.label_list(
             doc = "Other C# libraries, binaries, or imported DLLs",

--- a/csharp/private/runtimeconfig.json.tpl
+++ b/csharp/private/runtimeconfig.json.tpl
@@ -1,0 +1,9 @@
+{
+  "runtimeOptions": {
+    "tfm": "{RUNTIME_TFM}",
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "{RUNTIME_FRAMEWORK_VERSION}"
+    }
+  }
+}

--- a/csharp/private/sdk.bzl
+++ b/csharp/private/sdk.bzl
@@ -18,3 +18,6 @@ DOTNET_SDK = {
         "hash": "b38e6f8935d4b82b283d85c6b83cd24b5253730bab97e0e5e6f4c43e2b741aab",
     },
 }
+
+RUNTIME_TFM = "netcoreapp3.1"
+RUNTIME_FRAMEWORK_VERSION = "3.1.0"

--- a/docs/APIReference.md
+++ b/docs/APIReference.md
@@ -6,7 +6,7 @@
 
 <pre>
 csharp_binary(<a href="#csharp_binary-name">name</a>, <a href="#csharp_binary-additionalfiles">additionalfiles</a>, <a href="#csharp_binary-analyzers">analyzers</a>, <a href="#csharp_binary-defines">defines</a>, <a href="#csharp_binary-deps">deps</a>, <a href="#csharp_binary-include_stdrefs">include_stdrefs</a>, <a href="#csharp_binary-keyfile">keyfile</a>,
-              <a href="#csharp_binary-langversion">langversion</a>, <a href="#csharp_binary-out">out</a>, <a href="#csharp_binary-resources">resources</a>, <a href="#csharp_binary-srcs">srcs</a>, <a href="#csharp_binary-target_frameworks">target_frameworks</a>, <a href="#csharp_binary-winexe">winexe</a>)
+              <a href="#csharp_binary-langversion">langversion</a>, <a href="#csharp_binary-out">out</a>, <a href="#csharp_binary-resources">resources</a>, <a href="#csharp_binary-runtimeconfig_template">runtimeconfig_template</a>, <a href="#csharp_binary-srcs">srcs</a>, <a href="#csharp_binary-target_frameworks">target_frameworks</a>, <a href="#csharp_binary-winexe">winexe</a>)
 </pre>
 
 Compile a C# exe
@@ -26,6 +26,7 @@ Compile a C# exe
 | langversion |  The version string for the C# language.   | String | optional | "" |
 | out |  File name, without extension, of the built assembly.   | String | optional | "" |
 | resources |  A list of files to embed in the DLL as resources.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| runtimeconfig_template |  A template file to use for generating runtimeconfig.json   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | :runtimeconfig.json.tpl |
 | srcs |  C# source files.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | target_frameworks |  A list of target framework monikers to buildSee https://docs.microsoft.com/en-us/dotnet/standard/frameworks   | List of strings | optional | [] |
 | winexe |  If true, output a winexe-style executable, otherwiseoutput a console-style executable.   | Boolean | optional | False |

--- a/examples/basic/BUILD
+++ b/examples/basic/BUILD
@@ -9,7 +9,7 @@ load(
 csharp_binary(
     name = "hello",
     srcs = ["hello.cs"],
-    target_frameworks = ["net472"],
+    target_frameworks = ["netcoreapp3.0"],
     deps = [":lib"],
 )
 
@@ -20,12 +20,12 @@ csharp_binary(
 csharp_nunit_test(
     name = "lib_test",
     srcs = ["libtest.cs"],
-    target_frameworks = ["net472"],
+    target_frameworks = ["netcoreapp3.0"],
     deps = [":lib"],
 )
 
 csharp_library(
     name = "lib",
     srcs = ["lib.cs"],
-    target_frameworks = ["net472"],
+    target_frameworks = ["netcoreapp3.0"],
 )


### PR DESCRIPTION
This is half of #71. The other half is invoking the exe with `dotnet` rather than directly (I'm going to use the wrapper to do this, but in a follow-up PR).