### PR TITLE
Upgrade to Bazel 2.0.0 in CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,5 @@
 ---
-bazel: 1.2.1
+bazel: 2.0.0
 
 buildifier:
   version: latest


### PR DESCRIPTION
Upgrade bazel to the latest version in CI.

The full release announcement can be found in the [Blog entry on Bazel 2.0](https://blog.bazel.build/2019/12/19/bazel-2.0.html), and the release notes [here](https://github.com/bazelbuild/bazel/releases/tag/2.0.0).