### PR TITLE
Use public API instead of visibility to private

### DIFF
--- a/csharp/private/net/BUILD
+++ b/csharp/private/net/BUILD
@@ -1,5 +1,4 @@
-# buildifier: disable=bzl-visibility
-load("@d2l_rules_csharp//csharp/private:rules/imports.bzl", "import_multiframework_library")
+load("@d2l_rules_csharp//csharp:defs.bzl", "import_multiframework_library")
 
 import_multiframework_library(
     name = "StandardReferences",


### PR DESCRIPTION
The net workspace used for the framework dependencies is accessing a rule using an internal reference rather than using the public API.

This PR resolves the import to use the public API, rather than access private rules of rules_csharp.

This resolves the buildifier warning `bzl-visibility`