### PR TITLE
Generalize the dotnet wrapper a bit

### DIFF
--- a/csharp/private/actions/wrapper.bzl
+++ b/csharp/private/actions/wrapper.bzl
@@ -1,0 +1,36 @@
+"""
+An action that generates code for the C++ dotnet wrapper.
+"""
+
+def write_wrapper_main_cc(ctx, name, template, dotnetexe, argv1 = None, argv2 = None):
+    """Create the *.main.cc file which wraps dotnet.exe.
+
+    Args:
+      ctx: Rule context
+      name: The name of the associated target for this actione
+      template: The template .cc file
+      dotnetexe: The File object for dotnet.exe
+      argv1: (Optional) a value to inject as argv1
+      argv2: (Optional) a value to inject as argv2
+
+    Returns:
+      A File object to be used in a cc_binary target.
+    """
+
+    main_cc = ctx.actions.declare_file("%s.main.cc" % name)
+
+    # Trim leading "../"
+    # e.g. ../netcore-sdk-osx/dotnet
+    dotnetexe_path = dotnetexe.short_path[3:]
+
+    ctx.actions.expand_template(
+        template = template,
+        output = main_cc,
+        substitutions = {
+            "{DotnetExe}": dotnetexe_path,
+            "{Argv1}": argv1 or "",
+            "{Argv2}": argv2 or "",
+        },
+    )
+
+    return main_cc

--- a/csharp/private/rules/wrapper.bzl
+++ b/csharp/private/rules/wrapper.bzl
@@ -1,20 +1,11 @@
 """
 A wrapper around `dotnet` for Bazel.
 """
-_TEMPLATE = "//csharp/private:wrappers/dotnet.cc"
+
+load("//csharp/private:actions/wrapper.bzl", "write_wrapper_main_cc")
 
 def _dotnet_wrapper_impl(ctx):
-    cc_file = ctx.actions.declare_file("%s.cc" % (ctx.attr.name))
-    if len(ctx.files.src) < 1:
-        fail("No dotnet executable found in the SDK")
-
-    ctx.actions.expand_template(
-        template = ctx.file.template,
-        output = cc_file,
-        substitutions = {
-            "{DotnetExe}": ctx.files.src[0].short_path[3:],
-        },
-    )
+    cc_file = write_wrapper_main_cc(ctx, ctx.attr.name, ctx.file.template, ctx.files.src[0])
 
     files = depset(direct = [cc_file])
     return [
@@ -29,7 +20,7 @@ dotnet_wrapper = rule(
         "template": attr.label(
             doc = """Path to the program that will wrap the dotnet executable.
 This program will be compiled and used instead of directly calling the dotnet executable.""",
-            default = Label(_TEMPLATE),
+            default = Label("//csharp/private:wrappers/dotnet.cc"),
             allow_single_file = True,
         ),
         "src": attr.label_list(


### PR DESCRIPTION
`csharp_binary` needs to become a rule which emits a `cc_binary` that
invokes `dotnet <foo>`, where `<foo>` is the actual dll that we
compile, to solve #71. Eventually `<foo>` will become a wrapper C# exe
that tweaks assembly loading to solve #9. So all of this requires the
wrapper to provide a default `argv[1]`.

For stuff like `dotnet vstest` (#51) we will have `argv[1]` be `vstest`, so we
also need support for baking in `argv[2]`.