### PR TITLE
Remove reliance on path attribute for srcs arguments

### DIFF
--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -148,7 +148,7 @@ def AssemblyAction(
     args.add_all(additionalfiles, map_each = _format_additionalfile_arg)
 
     # .cs files
-    args.add_all([cs.path for cs in srcs])
+    args.add_all([cs for cs in srcs])
 
     # resources
     args.add_all(resources, map_each = _format_resource_arg)


### PR DESCRIPTION
In AssemblyAction, when adding arguments for the compiler command line, the [`args.add_all()`](https://docs.bazel.build/versions/master/skylark/lib/Args.html#add_all) call is looping through the `srcs` attribute, and adding the `.path` from each one. Since each element of the `srcs` attribute is a [File object](https://docs.bazel.build/versions/master/skylark/lib/File.html), adding the file names by calling `.path` is redundant; at rule execution time, the path is resolved and used as the string argument.

The motivation for this change is that `.add_all()` also understands File objects that are created with [`declare_directory()`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#declare_directory), meaning a rule invoking a source code generator can be used, and the output of that rule used directly (if created with
`actions.declare_directory()`).

Fixes #143 