### PR TITLE
Only wire up the internalsvisibleto codegen once rather than per-framework

### DIFF
--- a/csharp/private/actions/assembly.bzl
+++ b/csharp/private/actions/assembly.bzl
@@ -45,21 +45,6 @@ def _framework_preprocessor_symbols(tfm):
     else:
         return ["NETFRAMEWORK", specific]
 
-def _write_internalsvisibleto(actions, name, others):
-    attrs = actions.args()
-    attrs.set_param_file_format(format = "multiline")
-
-    attrs.add_all(
-        others, 
-        format_each = "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(\"%s\")]"
-    )
-
-    output = actions.declare_file("bazelout/%s/internalsvisibleto.cs" % name)
-
-    actions.write(output, attrs)
-
-    return output
-
 def AssemblyAction(
         actions,
         name,
@@ -90,7 +75,7 @@ def AssemblyAction(
         debug: Emits debugging information.
         defines: The list of conditional compilation symbols.
         deps: The list of other libraries to be linked in to the assembly.
-        internals_visible_to: Other C# libraries that can see the assembly's internal symbols.
+        internals_visible_to: An optional generated .cs file with InternalsVisibleTo attributes.
         keyfile: Specifies a strong name key file of the assembly.
         langversion: Specify language version: Default, ISO-1, ISO-2, 3, 4, 5, 6, 7, 7.1, 7.2, 7.3, or Latest
         resources: The list of resouces to be embedded in the assembly.
@@ -164,8 +149,8 @@ def AssemblyAction(
     args.add_all(analyzer_assemblies, map_each = _format_analyzer_arg)
     args.add_all(additionalfiles, map_each = _format_additionalfile_arg)
 
-    if len(internals_visible_to) != 0:
-        srcs = srcs + [_write_internalsvisibleto(actions, name, internals_visible_to)]
+    if internals_visible_to != None:
+        srcs = srcs + [internals_visible_to]
 
     # .cs files
     args.add_all([cs for cs in srcs])

--- a/csharp/private/rules/binary_private.bzl
+++ b/csharp/private/rules/binary_private.bzl
@@ -5,18 +5,28 @@ Base rule for compiling C# binaries and tests.
 load("//csharp/private:providers.bzl", "AnyTargetFrameworkInfo")
 load("//csharp/private:actions/assembly.bzl", "AssemblyAction")
 load(
+    "//csharp/private:actions/misc.bzl",
+    "write_internals_visible_to",
+    "write_runtimeconfig"
+)
+load(
     "//csharp/private:common.bzl",
     "fill_in_missing_frameworks",
     "is_core_framework",
     "is_debug",
     "is_standard_framework",
 )
-load("//csharp/private:actions/write_runtimeconfig.bzl", "write_runtimeconfig")
 
 def _binary_private_impl(ctx):
     providers = {}
 
     stdrefs = [ctx.attr._stdrefs] if ctx.attr.include_stdrefs else []
+
+    internals_visible_to = write_internals_visible_to(
+        ctx.actions,
+        name = ctx.attr.name,
+        others = ctx.attr.internals_visible_to,
+    )
 
     for tfm in ctx.attr.target_frameworks:
         if is_standard_framework(tfm):
@@ -39,7 +49,7 @@ def _binary_private_impl(ctx):
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
             deps = ctx.attr.deps + stdrefs,
-            internals_visible_to = ctx.attr.internals_visible_to,
+            internals_visible_to = internals_visible_to,
             keyfile = ctx.file.keyfile,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,

--- a/csharp/private/rules/library.bzl
+++ b/csharp/private/rules/library.bzl
@@ -3,6 +3,7 @@ Rules for compiling C# libraries.
 """
 load("//csharp/private:providers.bzl", "AnyTargetFrameworkInfo")
 load("//csharp/private:actions/assembly.bzl", "AssemblyAction")
+load("//csharp/private:actions/misc.bzl", "write_internals_visible_to")
 load(
     "//csharp/private:common.bzl",
     "fill_in_missing_frameworks",
@@ -14,6 +15,12 @@ def _library_impl(ctx):
 
     stdrefs = [ctx.attr._stdrefs] if ctx.attr.include_stdrefs else []
 
+    internals_visible_to = write_internals_visible_to(
+        ctx.actions,
+        name = ctx.attr.name,
+        others = ctx.attr.internals_visible_to,
+    )
+
     for tfm in ctx.attr.target_frameworks:
         providers[tfm] = AssemblyAction(
             ctx.actions,
@@ -23,7 +30,7 @@ def _library_impl(ctx):
             debug = is_debug(ctx),
             defines = ctx.attr.defines,
             deps = ctx.attr.deps + stdrefs,
-            internals_visible_to = ctx.attr.internals_visible_to,
+            internals_visible_to = internals_visible_to,
             keyfile = ctx.file.keyfile,
             langversion = ctx.attr.langversion,
             resources = ctx.files.resources,


### PR DESCRIPTION
Also standardize on internals_visible_to rather than internalsvisibleto.

Part of #150 